### PR TITLE
Updated GraphViz -- removed base file creation and .gif

### DIFF
--- a/test/test-gviz.cpp
+++ b/test/test-gviz.cpp
@@ -105,7 +105,7 @@ TEST(GVizTest, DrawGVizColor) {
   LNames.Add("Circo");
   
   TStrV Exts;
-  //Exts.Add("ps");
+  Exts.Add("ps");
   //Exts.Add("gif");
   Exts.Add("png");
   Exts.Add("dot");
@@ -133,14 +133,10 @@ TEST(GVizTest, DrawGVizColor) {
 
           // Draw new graph and check if created and equal to baseline (for ps only)
           if (IsDir) {
-//            TSnap::DrawGViz(NGraph1, TGVizLayout(i), FNameBase, LNames[i],
-//                            true, NIdColorH);
             TSnap::DrawGViz(NGraph1, TGVizLayout(i), FNameTest, LNames[i],
                             true, NIdColorH);
           }
           else {
-//            TSnap::DrawGViz(UNGraph1, TGVizLayout(i), FNameBase, LNames[i],
-//                            true, NIdColorH);
             TSnap::DrawGViz(UNGraph1, TGVizLayout(i), FNameTest, LNames[i],
                             true, NIdColorH);
           }
@@ -148,14 +144,6 @@ TEST(GVizTest, DrawGVizColor) {
         
         // Check if file exists
         EXPECT_TRUE(fileExists(FNameTest.CStr()));
-                
-#ifdef __linux
-        // Compare directly for ps files on Linux,
-        // (can't compare png and gif due to EXIF-labels)
-        if (Exts[e] == "ps") {
-          EXPECT_TRUE(compareFiles(FNameBase.CStr(), FNameTest.CStr()));
-        }
-#endif
       }
     }
   }


### PR DESCRIPTION
I updated GViz again and removed some of the file comparisons when the base files was OS-dependent (different base files for Linux and Mac, and possibly others).  The comparison of the DOT files is still there.  It passes on Mac and Linux.

That is weird that it says "gif" not recognized.  I ran it on my Mac and on Madmax with neato version 2.26 and it was able to generate the .gif extension fine.

neato -V
neato - graphviz version 2.26.0 (20091210.2329)

I kept the Exts.Add("gif") commented out for now, since it is not essential.  Perhaps it only works only on specific OS's.  I kept the gif test out for now, but we can try it later if we would like to include it.
