### PR TITLE
changed functional casts in unicode.h to c-type casts. Needed to compile on GCC 4.8.1

### DIFF
--- a/glib-core/unicode.h
+++ b/glib-core/unicode.h
@@ -1028,13 +1028,13 @@ public:
 	ushort lineBreak; // from LineBreak.txt
 
 	// Converts a 2-letter linebreak code into a 16-bit integer.
-	static inline ushort GetLineBreakCode(char c1, char c2) { return ((ushort(uchar(c1)) & 0xff) << 8) | ((ushort(uchar(c2)) & 0xff)); }
+	static inline ushort GetLineBreakCode(char c1, char c2) { return (((ushort)((uchar)c1) & 0xff) << 8) | (((ushort)((uchar)c2) & 0xff)); }
 	static const ushort LineBreak_Unknown, LineBreak_ComplexContext, LineBreak_Numeric, LineBreak_InfixNumeric, LineBreak_Quotation;
 
 public:
 	void InitAfterLoad() {
 		cat = (TUniChCategory) chCat;
-		subCat = (TUniChSubCategory) (((int(uchar(chCat)) & 0xff) << 8) | (int(uchar(chSubCat)) & 0xff)); }
+		subCat = (TUniChSubCategory) ((((int)((uchar)chCat) & 0xff) << 8) | ((int)((uchar)chSubCat) & 0xff)); }
 	void SetCatAndSubCat(const TUniChSubCategory catAndSubCat) {
 		cat = (TUniChCategory) ((int(catAndSubCat) >> 8) & 0xff);
 		subCat = catAndSubCat;


### PR DESCRIPTION
changed functional casts to c-type casts for two lines in glib-core/unicode.h 
This is needed to compile with GCC 4.8.1 on OSX 10.8 and Fedora 19. 
The latest Intel compiler works in both cases with messages about ignoring packing.

Prior to the change snap would not compile with GCC 4.8.1 on OSX 10.8 or Fedora 19 with error message below. Changing the casts in the two lines in unicode.h resulted in compilation using GCC 4.8.1 on both platforms. 

[alanw@localhost snap]$ make all
make -C snap-core
make[1]: Entering directory `/home/alanw/temp1/snap/snap-core'
g++ -c -std=c++98 -Wall -O3 Snap.cpp -I../glib-core
In file included from ../glib-core/base.h:154:0,
                 from Snap.h:8,
                 from Snap.cpp:4:
../glib-core/unicode.h: In static member function ‘static ushort TUniChInfo::GetLineBreakCode(char, char)’:
../glib-core/unicode.h:1031:87: error: invalid qualifiers on non-member function type
  static inline ushort GetLineBreakCode(char c1, char c2) { return ((ushort(uchar(c1)) & 0xff) << 8) | ((ushort(uchar(c2)) & 0xff)); }
                                                                                       ^
../glib-core/unicode.h:1031:87: error: invalid qualifiers on non-member function type
../glib-core/unicode.h:1031:123: error: invalid qualifiers on non-member function type
  static inline ushort GetLineBreakCode(char c1, char c2) { return ((ushort(uchar(c1)) & 0xff) << 8) | ((ushort(uchar(c2)) & 0xff)); }
                                                                                                                           ^
../glib-core/unicode.h:1031:123: error: invalid qualifiers on non-member function type
../glib-core/unicode.h: In member function ‘void TUniChInfo::InitAfterLoad()’:
../glib-core/unicode.h:1037:53: error: invalid qualifiers on non-member function type
   subCat = (TUniChSubCategory) (((int(uchar(chCat)) & 0xff) << 8) | (int(uchar(chSubCat)) & 0xff)); }
                                                     ^
../glib-core/unicode.h:1037:53: error: invalid qualifiers on non-member function type
../glib-core/unicode.h:1037:91: error: invalid qualifiers on non-member function type
   subCat = (TUniChSubCategory) (((int(uchar(chCat)) & 0xff) << 8) | (int(uchar(chSubCat)) & 0xff)); }
                                                                                           ^
../glib-core/unicode.h:1037:91: error: invalid qualifiers on non-member function type
dmake[1]: *** [Snap.o] Error 1
make[1]: Leaving directory`/home/alanw/temp1/snap/snap-core'
make: **\* [MakeAll] Error 2
