### PR TITLE
Use KeyId instead of NId for TNEANet attributes

### DIFF
--- a/snap-core/network.cpp
+++ b/snap-core/network.cpp
@@ -237,19 +237,19 @@ bool TNEANet::EdgeAttrIsDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI)
 bool TNEANet::EdgeAttrIsIntDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const {
   return (EdgeHI.GetDat().Val1 == IntType &&
     GetIntAttrDefaultE(EdgeHI.GetKey()) == this->VecOfIntVecsE.GetVal(
-    this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EId));
+    this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EdgeH.GetKeyId(EId)));
 }
 
 bool TNEANet::EdgeAttrIsStrDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const {
   return (EdgeHI.GetDat().Val1 == StrType &&
     GetStrAttrDefaultE(EdgeHI.GetKey()) == this->VecOfStrVecsE.GetVal(
-    this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EId));
+    this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EdgeH.GetKeyId(EId)));
 }
 
 bool TNEANet::EdgeAttrIsFltDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const {
   return (EdgeHI.GetDat().Val1 == FltType &&
     GetFltAttrDefaultE(EdgeHI.GetKey()) == this->VecOfFltVecsE.GetVal(
-    this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EId));
+    this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EdgeH.GetKeyId(EId)));
 }
 
 TStr TNEANet::GetEdgeAttrValue(const int& EId, const TStrIntPrH::TIter& EdgeHI) const {

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1778,7 +1778,7 @@ public:
     return TAIntI(VecOfIntVecsN[KeyToIndexTypeN.GetDat(attr).Val2].EndI(), attr, false, this); }
   /// Returns an iterator referring to the node of ID NId in the graph.
   TAIntI GetNAIntI(const TStr& attr, const int& NId) const {
-    return TAIntI(VecOfIntVecsN[KeyToIndexTypeN.GetDat(attr).Val2].GetI(NId), attr, false, this); }
+    return TAIntI(VecOfIntVecsN[KeyToIndexTypeN.GetDat(attr).Val2].GetI(NodeH.GetKeyId(NId)), attr, false, this); }
   /// Returns an iterator referring to the first node's str attribute.
   TAStrI BegNAStrI(const TStr& attr) const {
 
@@ -1788,7 +1788,7 @@ public:
     return TAStrI(VecOfStrVecsN[KeyToIndexTypeN.GetDat(attr).Val2].EndI(), attr, false, this); }
   /// Returns an iterator referring to the node of ID NId in the graph.
   TAStrI GetNAStrI(const TStr& attr, const int& NId) const {
-    return TAStrI(VecOfStrVecsN[KeyToIndexTypeN.GetDat(attr).Val2].GetI(NId), attr, false, this); }
+    return TAStrI(VecOfStrVecsN[KeyToIndexTypeN.GetDat(attr).Val2].GetI(NodeH.GetKeyId(NId)), attr, false, this); }
   /// Returns an iterator referring to the first node's flt attribute.
   TAFltI BegNAFltI(const TStr& attr) const {
     return TAFltI(VecOfFltVecsN[KeyToIndexTypeN.GetDat(attr).Val2].BegI(), attr, false, this); }
@@ -1797,7 +1797,7 @@ public:
     return TAFltI(VecOfFltVecsN[KeyToIndexTypeN.GetDat(attr).Val2].EndI(), attr, false, this); }
   /// Returns an iterator referring to the node of ID NId in the graph.
   TAFltI GetNAFltI(const TStr& attr, const int& NId) const {
-    return TAFltI(VecOfFltVecsN[KeyToIndexTypeN.GetDat(attr).Val2].GetI(NId), attr, false, this); }
+    return TAFltI(VecOfFltVecsN[KeyToIndexTypeN.GetDat(attr).Val2].GetI(NodeH.GetKeyId(NId)), attr, false, this); }
 
   /// Returns a vector of attr names for node NId.
   void AttrNameNI(const TInt& NId, TStrV& Names) const {
@@ -1875,7 +1875,7 @@ public:
   }
   /// Returns an iterator referring to the node of ID EId in the graph.
   TAIntI GetEAIntI(const TStr& attr, const int& EId) const {
-    return TAIntI(VecOfIntVecsE[KeyToIndexTypeE.GetDat(attr).Val2].GetI(EId), attr, true, this);
+    return TAIntI(VecOfIntVecsE[KeyToIndexTypeE.GetDat(attr).Val2].GetI(EdgeH.GetKeyId(EId)), attr, true, this);
   }
   /// Returns an iterator referring to the first node's str attribute.
   TAStrI BegEAStrI(const TStr& attr) const {
@@ -1886,7 +1886,7 @@ public:
   }
   /// Returns an iterator referring to the node of ID EId in the graph.
   TAStrI GetEAStrI(const TStr& attr, const int& EId) const {
-    return TAStrI(VecOfStrVecsE[KeyToIndexTypeE.GetDat(attr).Val2].GetI(EId), attr, true, this);
+    return TAStrI(VecOfStrVecsE[KeyToIndexTypeE.GetDat(attr).Val2].GetI(EdgeH.GetKeyId(EId)), attr, true, this);
   }
   /// Returns an iterator referring to the first node's flt attribute.
   TAFltI BegEAFltI(const TStr& attr) const {
@@ -1898,7 +1898,7 @@ public:
   }
   /// Returns an iterator referring to the node of ID EId in the graph.
   TAFltI GetEAFltI(const TStr& attr, const int& EId) const {
-    return TAFltI(VecOfFltVecsE[KeyToIndexTypeE.GetDat(attr).Val2].GetI(EId), attr, true, this);
+    return TAFltI(VecOfFltVecsE[KeyToIndexTypeE.GetDat(attr).Val2].GetI(EdgeH.GetKeyId(EId)), attr, true, this);
   }
   /// Returns the maximum id of a any node in the graph.
   int GetMxNId() const { return MxNId; }

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,7 @@ LIBS += -lgtest
 ## Main application file
 MAIN = run-all-tests
 
-TESTS = \
+TEST_SRCS = \
 	test-helper.cpp \
 	test-TUNGraph.cpp test-TNGraph.cpp \
 	test-TNEGraph.cpp test-TNEANet.cpp \
@@ -27,12 +27,17 @@ TESTS = \
 	test-THash.cpp \
 	test-THashSet.cpp
 
+TEST_OBJS = $(TEST_SRCS:.cpp=.o)
+
 all: $(MAIN)
 run: test
 
 # COMPILE
-$(MAIN): $(MAIN).cpp $(TESTS) $(CSNAP)/Snap.o
-	$(CC) $(CXXFLAGS) -o $(MAIN) $(MAIN).cpp $(TESTS) $(CSNAP)/Snap.o -I$(CSNAP) -I$(CGLIB) $(LDFLAGS) $(LIBS)
+.cpp.o:
+	$(CC) $(CXXFLAGS) -I$(CSNAP) -I$(CGLIB) -c $<
+
+$(MAIN): $(MAIN).o $(TEST_OBJS) $(CSNAP)/Snap.o
+	$(CC) $(CXXFLAGS) -o $(MAIN) $^ -I$(CSNAP) -I$(CGLIB) $(LDFLAGS) $(LIBS)
 
 $(CSNAP)/Snap.o:
 	$(MAKE) -C $(CSNAP)

--- a/test/test-TNEANet.cpp
+++ b/test/test-TNEANet.cpp
@@ -175,14 +175,14 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   t = Graph->Empty();
 
   // create the nodes
-  for (i = 0; i < NNodes; i++) {
+  for (i = NNodes - 1; i >= 0; i--) {
     Graph->AddNode(i);
   }
 
   EXPECT_EQ(NNodes, Graph->GetNodes());
 
   // create the edges 
-  for (i = 0; i < NEdges; i++) {
+  for (i = NEdges - 1; i >= 0; i--) {
     x = (long) (drand48() * NNodes);
     y = (long) (drand48() * NNodes);
     Graph->AddEdge(x, y, i);
@@ -201,6 +201,10 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   Graph->AddIntAttrDatN(50, 50*2, attr2);
   Graph->AddIntAttrDatN(700, 700*2, attr2);
   Graph->AddIntAttrDatN(900, 900*2, attr2);
+
+  EXPECT_EQ(3*2, Graph->GetNAIntI(attr2, 3).GetDat());
+  EXPECT_EQ(50*2, Graph->GetNAIntI(attr2, 50).GetDat());
+
   int NodeId = 0;
   int DefNodes = 0;
   TVec<TInt> TAIntIV = TVec<TInt>();
@@ -227,6 +231,10 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   Graph->AddFltAttrDatN(50, 2.718, attr3);
   Graph->AddFltAttrDatN(300, 150.0, attr3);
   Graph->AddFltAttrDatN(653, 563, attr3);
+
+  EXPECT_EQ(3.41, Graph->GetNAFltI(attr3, 5).GetDat());
+  EXPECT_EQ(2.718, Graph->GetNAFltI(attr3, 50).GetDat());
+
   NodeId = 0;
   DefNodes = 0;
   TVec<TFlt> TAFltIV = TVec<TFlt>();
@@ -255,6 +263,10 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   Graph->AddStrAttrDatN(400, "ghi", attr1);
   // this does not show since ""=null
   Graph->AddStrAttrDatN(455, "", attr1);
+
+  EXPECT_EQ('c', Graph->GetNAStrI(attr1, 10).GetDat().LastCh());
+  EXPECT_EQ('f', Graph->GetNAStrI(attr1, 20).GetDat().LastCh());
+
   NodeId = 0;
   DefNodes = 0;
   TVec<TStr> TAStrIV = TVec<TStr>();
@@ -324,8 +336,11 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
     }
   } 
 
+  int expectedTotal = 0;
   for (i = 0; i <NNodes; i++) {
-    Graph->AddIntAttrDatN(i, 70, attr2);
+    Graph->AddIntAttrDatN(i, NNodes+i, attr2);
+    EXPECT_EQ(NNodes+i, Graph->GetIntAttrDatN(i, attr2));
+    expectedTotal += NNodes+i;
   }
 
   {
@@ -345,7 +360,7 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
     total += NI.GetDat();
   }
 
-  ASSERT_EQ(70, total/NNodes);
+  ASSERT_EQ(expectedTotal, total);
 
   Graph1->Clr();
 
@@ -354,6 +369,10 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   Graph->AddIntAttrDatE(55, 55*2, attr2);
   Graph->AddIntAttrDatE(705, 705*2, attr2);
   Graph->AddIntAttrDatE(905, 905*2, attr2);
+
+  EXPECT_EQ(3*2, Graph->GetEAIntI(attr2, 3).GetDat());
+  EXPECT_EQ(55*2, Graph->GetEAIntI(attr2, 55).GetDat());
+
   int EdgeId = 0;
   int DefEdges = 0;
   TAIntIV.Clr();
@@ -381,6 +400,10 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   Graph->AddFltAttrDatE(50, 3.718, attr3);
   Graph->AddFltAttrDatE(300, 151.0, attr3);
   Graph->AddFltAttrDatE(653, 654, attr3);
+
+  EXPECT_EQ(4.41, Graph->GetEAFltI(attr3, 5).GetDat());
+  EXPECT_EQ(3.718, Graph->GetEAFltI(attr3, 50).GetDat());
+
   EdgeId = 0;
   DefEdges = 0;
   TAFltIV.Clr();
@@ -410,6 +433,10 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   Graph->AddStrAttrDatE(400, "ghi", attr1);
   // this does not show since ""=null
   Graph->AddStrAttrDatE(455, "", attr1);
+
+  EXPECT_EQ('c', Graph->GetEAStrI(attr1, 10).GetDat().LastCh());
+  EXPECT_EQ('f', Graph->GetEAStrI(attr1, 20).GetDat().LastCh());
+
   EdgeId = 0;
   DefEdges = 0;
   TAStrIV.Clr();
@@ -475,8 +502,11 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
     }
   }
 
+  expectedTotal = 0;
   for (i = 0; i <NEdges; i++) {
-    Graph->AddIntAttrDatE(i, 70, attr2);
+    Graph->AddIntAttrDatE(i, NEdges+i, attr2);
+    EXPECT_EQ(NEdges+i, Graph->GetIntAttrDatE(i, attr2));
+    expectedTotal += NEdges+i;
   }
 
   {
@@ -497,7 +527,7 @@ TEST(TNEANet, ManipulateNodesEdgeAttributes) {
     total += EI.GetDat();
   }
 
-  EXPECT_EQ(70, total/NEdges);
+  EXPECT_EQ(expectedTotal, total);
 
   //Graph1->Dump();
   Graph1->Clr();


### PR DESCRIPTION
Add{Int,Str,Flt}AttrDat[NE] use the NodeH.GetKeyId(NId) and
EdgeH.GetKeyId(EId) for their index into the attribute vectors, but the
rest of the functions did not. This would allow the functions to still
work if all the nodes corresponded exactly between the NId and the
KeyId, but this doesn't happen when you use LoadEdgeList.
