### PR TITLE
fix up SendVec64

### DIFF
--- a/snap-core/util.h
+++ b/snap-core/util.h
@@ -75,9 +75,10 @@ extern int WriteN(int fd, char *ptr, int nbytes);
 
 /// Sends the vector contents \c V via a file/socket descriptor \c FileDesc.
 /// Returns the number of bytes sent. If return value is negative, then some system call returned an error.
+/// Note: use int64 in unlikely case that V has more than INT_MAX bytes send.
 template <class TVal, class TSizeTy>
-int SendVec(const TVec<TVal, TSizeTy>& V, int FileDesc) {
-  int l = 0;
+int64 SendVec(const TVec<TVal, TSizeTy>& V, int FileDesc) {
+  int64 l = 0;
   int n;
   int r;
   TSizeTy Vals = V.Len();
@@ -108,5 +109,40 @@ int SendVec(const TVec<TVal, TSizeTy>& V, int FileDesc) {
   }
   return l;
 }
-#endif
 
+
+/// Sends the segmented vector contents \c V via a file/socket descriptor \c FileDesc.
+/// Returns the number of bytes sent. If return value is negative, then some system call returned an error.
+/// Unfortunately, C++ doesn't have templated typedefs, so we have to deal with this
+/// very nasty TVec of TVec's type. C++11 has alias declarations which can achieve
+/// templated-typedef-like behavior, but SNAP compiles with C++98. One possible alternative
+/// is to create a child class w/ template specialization, but that is not done here.
+template <class TVal, class TSizeTy>
+int64 SendVec64(const TVec< TVec< TVal, TSizeTy > , TSizeTy >&Vec64, int FileDesc) {
+TSizeTy N =Vec64.Len();
+  int64 l=0;
+  int r;
+
+  r = WriteN(FileDesc, (char *) &N, (int) sizeof(TSizeTy));
+  if (r < 0) {
+    return r;
+  }
+  l += r;
+
+  r = WriteN(FileDesc, (char *) &N, (int) sizeof(TSizeTy));
+  if (r < 0) {
+    return r;
+  }
+  l += r;
+
+  for (typename TVec< TVec< TVal, TSizeTy >, TSizeTy >::TIter it=Vec64.BegI(); it!=Vec64.EndI(); ++it) {
+    r = SendVec(*it, FileDesc);
+    if (r < 0) {
+      return r;
+    }
+    l += r;
+  }
+
+  return l;
+}
+#endif


### PR DESCRIPTION
Took into account Rok's comments and fixed up SendVec64 function (used for segmented bfs). Also fixed whitespace / tab issues.
