### PR TITLE
Allow non-consecutive node numbering for BigClam input graphs.

### DIFF
--- a/examples/bigclam/bigclam.cpp
+++ b/examples/bigclam/bigclam.cpp
@@ -31,14 +31,14 @@ int main(int argc, char* argv[]) {
   if (InFNm.IsStrIn(".ungraph")) {
     TFIn GFIn(InFNm);
     G = TUNGraph::Load(GFIn);
-  } else {
-    G = TAGMUtil::LoadEdgeListStr<PUNGraph>(InFNm, NIDNameH);
-  }
-  if (LabelFNm.Len() > 0) {
+  } else if (LabelFNm.Len() > 0) {
+    G = TSnap::LoadEdgeList<PUNGraph>(InFNm);
     TSsParser Ss(LabelFNm, ssfTabSep);
     while (Ss.Next()) {
       if (Ss.Len() > 0) { NIDNameH.AddDat(Ss.GetInt(0), Ss.GetFld(1)); }
     }
+  } else {
+    G = TAGMUtil::LoadEdgeListStr<PUNGraph>(InFNm, NIDNameH);
   }
   printf("Graph: %d Nodes %d Edges\n", G->GetNodes(), G->GetEdges());
   


### PR DESCRIPTION
Currently, if the input file for BigClam calculations has non-consecutive node numbers and a label file (`-l`) is provided, the output generated is incorrect.

This commit fixes the problem by handling the input files in the same way as `agmfitmain.cpp`.