### PR TITLE
GetEgonet() -- fix so in-edges to center node included

### DIFF
--- a/snap-core/subgraph.cpp
+++ b/snap-core/subgraph.cpp
@@ -130,7 +130,9 @@ PNGraph GetEgonet(const PNGraph& Graph, const int CtrNId, int& InEdges, int& Out
     }
     for (int j = 0; j < NbrNode.GetOutDeg(); ++j) {
       int NbrNbrNId = NbrNode.GetOutNId(j);
-      if (!NewGraph.IsNode(NbrNbrNId)) {
+      if (NewGraph.IsNode(NbrNbrNId)) {
+        NewGraph.AddEdge(NbrNId, NbrNbrNId);
+      } else {
         OutEdges++;
       }
     }


### PR DESCRIPTION
This is a very small change to the GetEgonet() method for directed networks. 
The original code misses adding in-edges to the center node (it loops over the neighbors adding only edges in one direction). Duplicate edges appear to be quietly ignored, anyways, so I simply made the function symmetric. This fixes the problem in an elegant way?