### PR TITLE
[trivial] [cesna] Fix discrepancy between code and README

### DIFF
--- a/examples/cesna/ReadMe.txt
+++ b/examples/cesna/ReadMe.txt
@@ -40,7 +40,7 @@ Parameters:
    
    The following two parameters are for backracking line search described in Convex Optimization, Boyd and Vandenberghe, 2004.
    Refer to the book for the backtracking line search algorithm.
-   -sa:Alpha for backtracking line search (default:0.3)
+   -sa:Alpha for backtracking line search (default:0.05)
    -sb:Beta for backtracking line search (default:0.3)
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In the cesna example, the actual value for alpha in the backtracking search is set to 0.05 by default, current readme says 0.3.