### PR TITLE
Ignore self loops in temporal motifs counting.

### DIFF
--- a/snap-adv/temporalmotifs.cpp
+++ b/snap-adv/temporalmotifs.cpp
@@ -139,7 +139,7 @@ void TempMotifCounter::Count3TEdge23Node(double delta, Counter2D& counts) {
   counts(1, 1) = mid_counts(1, 0, 0);
   counts(1, 4) = pos_counts(1, 0, 0);
   counts(1, 5) = pos_counts(1, 0, 1);
-  counts(2, 0) = mid_counts(0, 0, 1);
+  counts(2, 0) = mid_counts(0, 1, 0);
   counts(2, 1) = mid_counts(0, 1, 1);
   counts(2, 2) = pos_counts(0, 1, 0);
   counts(2, 3) = pos_counts(0, 1, 1);

--- a/snap-adv/temporalmotifs.cpp
+++ b/snap-adv/temporalmotifs.cpp
@@ -27,7 +27,9 @@ TempMotifCounter::TempMotifCounter(const TStr& filename) {
     int src = data_ptr->GetIntValAtRowIdx(src_idx, row_idx).Val;
     int dst = data_ptr->GetIntValAtRowIdx(dst_idx, row_idx).Val;
     int tim = data_ptr->GetIntValAtRowIdx(tim_idx, row_idx).Val;
-    temporal_data_[src](dst).Add(tim);
+    // Do not include self loops as they do not appear in the definition of
+    // temporal motifs.
+    if (src != dst) { temporal_data_[src](dst).Add(tim); }
   }
 }
 


### PR DESCRIPTION
A bug was reported on the counts of temporal motifs. The cause was the inclusion of self-loops, which should not contribute towards the counts of temporal motifs (as defined for this implementation). This pull request fixes this issue.