### PR TITLE
Fix bugs in temporal motif counting

### DIFF
--- a/snap-adv/temporalmotifs.cpp
+++ b/snap-adv/temporalmotifs.cpp
@@ -139,7 +139,7 @@ void TempMotifCounter::Count3TEdge23Node(double delta, Counter2D& counts) {
   counts(1, 1) = mid_counts(1, 0, 0);
   counts(1, 4) = pos_counts(1, 0, 0);
   counts(1, 5) = pos_counts(1, 0, 1);
-  counts(2, 0) = mid_counts(0, 0, 1);
+  counts(2, 0) = mid_counts(0, 1, 0);
   counts(2, 1) = mid_counts(0, 1, 1);
   counts(2, 2) = pos_counts(0, 1, 0);
   counts(2, 3) = pos_counts(0, 1, 1);

--- a/snap-adv/temporalmotifs.cpp
+++ b/snap-adv/temporalmotifs.cpp
@@ -27,7 +27,9 @@ TempMotifCounter::TempMotifCounter(const TStr& filename) {
     int src = data_ptr->GetIntValAtRowIdx(src_idx, row_idx).Val;
     int dst = data_ptr->GetIntValAtRowIdx(dst_idx, row_idx).Val;
     int tim = data_ptr->GetIntValAtRowIdx(tim_idx, row_idx).Val;
-    temporal_data_[src](dst).Add(tim);
+    // Do not include self loops as they do not appear in the definition of
+    // temporal motifs.
+    if (src != dst) { temporal_data_[src](dst).Add(tim); }
   }
 }
 


### PR DESCRIPTION
Two bugs were pointed out by users:
(1) Self-loops should be ignored
(2) The output file had a bug that copied the same motif count twice

Each bug fix is a one-liner.
