### PR TITLE
Update progress indicators after finishing walking and learning

### DIFF
--- a/snap-adv/n2v.cpp
+++ b/snap-adv/n2v.cpp
@@ -33,7 +33,7 @@ void node2vec(PWNet& InNet, const double& ParamP, const double& ParamQ,
     }
   }
   if (Verbose) {
-    printf("\n");
+    printf("\rWalking Progress: %.2lf%%\n",100);
     fflush(stdout);
   }
   //Learning embeddings

--- a/snap-adv/word2vec.cpp
+++ b/snap-adv/word2vec.cpp
@@ -154,6 +154,10 @@ void TrainModel(TVVec<TInt, int64>& WalksVV, const int& Dimensions,
     }
     WordCntAll++;
   }
+  if ( Verbose ) {
+    printf("\rLearning Progress: %.2lf%% ",100);
+    fflush(stdout);
+  }
 }
 
 


### PR DESCRIPTION
Right now, the progress indicators end at 99.XX%, which looks like the walking and learning never finished.

I have matched the formatting of the progress prints in each of the two files, which is the reason for the different whitespace around `Verbose` and the extra space at the end of the format string in `word2vec.cpp`.