### PR TITLE
SaveLEDA Functionality

### DIFF
--- a/snap-core/gio.h
+++ b/snap-core/gio.h
@@ -351,7 +351,7 @@ void SaveMatlabSparseMtx(const PGraph& Graph, const TStr& OutFNm) {
 
 // Output has three sections: header, nodes section, and edges section
 // See http://www.algorithmic-solutions.info/leda_guide/graphs/leda_native_graph_fileformat.html
-// for details.
+// for details...
 template <class PGraph>
 void SaveLEDA(const PGraph& Graph, const TStr& OutFNm) {
   FILE *F = fopen(OutFNm.CStr(), "wt");


### PR DESCRIPTION
There are a few network packages/methods out there that require a [LEDA-formatted](http://www.algorithmic-solutions.info/leda_guide/graphs/leda_native_graph_fileformat.html) file as input (for example, [Graphlet-based network comparison distances](http://www0.cs.ucl.ac.uk/staff/N.Przulj/GCD/index.html)). It's obviously not impossible to code up yourself a LEDA file from the raw edge outputs that SNAP provides, but it would be nice to have saving to a LEDA-format file built in to the SNAP functionality. So I wrote a function that does that. I'm not sure exactly what all needs to happen to make that part of the make file/namespace/documentation, but I'm happy to help where I can. 