### PR TITLE
Fix build error with GLIBC >=2.27

### DIFF
--- a/glib-core/bd.cpp
+++ b/glib-core/bd.cpp
@@ -10,10 +10,15 @@ int std::_matherr(struct math_exception* e){
   return 1;
 }
 #elif defined(GLib_GLIBC) || defined(GLib_BSD)
+
+#include <features.h>
+#if !__GLIBC_PREREQ(2, 27) /* facility removed as part of glibc 2.27 */
 int _matherr(struct __exception* e){
   e->retval=0;
   return 1;
 }
+#endif
+
 #elif defined(GLib_SOLARIS)
 int _matherr(struct __math_exception* e){
   e->retval=0;


### PR DESCRIPTION
The facility to handle exceptions with matherr has been removed on glibc 2.27, see http://man7.org/linux/man-pages/man3/matherr.3.html 
This patch disables the usage of this mechanism in the code with the newer versions of glibc.