### PR TITLE
Dense floating-point vector attributes

### DIFF
--- a/snap-core/network.cpp
+++ b/snap-core/network.cpp
@@ -141,7 +141,6 @@ void TNEANet::IntVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TI
   }
 }
 
-// Avery
 void TNEANet::FltVAttrNameNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TStrV& Names) const {
   Names = TVec<TStr>();
   while (!NodeHI.IsEnd()) {
@@ -152,7 +151,6 @@ void TNEANet::FltVAttrNameNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TStrV& N
   }  
 }
 
-// Avery
 void TNEANet::FltVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TFltV>& Values) const {
   Values = TVec<TFltV>();
   while (!NodeHI.IsEnd()) {
@@ -618,7 +616,6 @@ int TNEANet::AddAttributes(const int NId) {
       IntVecV.Ins(KeyId, TIntV());
     }
   }
-  // Avery
   for (i = 0; i < VecOfFltVecVecsN.Len(); i++) {
     TVec<TFltV>& FltVecV = VecOfFltVecVecsN[i];
     int KeyId = NodeH.GetKeyId(NId);
@@ -734,7 +731,6 @@ void TNEANet::DelNode(const int& NId) {
     TVec<TIntV>& IntVecV = VecOfIntVecVecsN[i];
     IntVecV[NodeH.GetKeyId(NId)] = TIntV();
   }
-  // Avery
   for (i = 0; i < VecOfFltVecVecsN.Len(); i++) {
     TVec<TFltV>& FltVecV = VecOfFltVecVecsN[i];
     FltVecV[NodeH.GetKeyId(NId)] = TFltV();
@@ -1078,7 +1074,6 @@ int TNEANet::AddIntVAttrDatN(const int& NId, const TIntV& value, const TStr& att
   return 0;
 } 
 
-// Avery
 int TNEANet::AddFltVAttrDatN(const int& NId, const TFltV& value, const TStr& attr, TBool UseDense) {
   if (!IsNode(NId)) {
     // AddNode(NId);
@@ -1126,7 +1121,7 @@ int TNEANet::AppendIntVAttrDatN(const int& NId, const TInt& value, const TStr& a
   return 0;
 } 
 
-// Avery
+
 int TNEANet::AppendFltVAttrDatN(const int& NId, const TFlt& value, const TStr& attr, TBool UseDense) {
   if (!IsNode(NId)) {
     // AddNode(NId);
@@ -1177,7 +1172,7 @@ int TNEANet::DelFromIntVAttrDatN(const int& NId, const TInt& value, const TStr& 
   return 0;
 } 
 
-// Avery
+
 int TNEANet::DelFromFltVAttrDatN(const int& NId, const TFlt& value, const TStr& attr) {
   TInt CurrLen;
   if (!IsNode(NId)) {
@@ -1295,7 +1290,7 @@ int TNEANet::AddIntVAttrDatE(const int& EId, const TIntV& value, const TStr& att
   return 0;
 } 
 
-// Avery
+
 int TNEANet::AddFltVAttrDatE(const int& EId, const TFltV& value, const TStr& attr, TBool UseDense) {
   if (!IsEdge(EId)) {
     // AddNode(NId);
@@ -1338,7 +1333,7 @@ int TNEANet::AppendIntVAttrDatE(const int& EId, const TInt& value, const TStr& a
   return 0;
 }
 
-// Avery
+
 int TNEANet::AppendFltVAttrDatE(const int& EId, const TFlt& value, const TStr& attr, TBool UseDense) {
   if (!IsEdge(EId)) {
     // AddNode(NId);
@@ -1422,7 +1417,7 @@ TIntV TNEANet::GetIntVAttrDatN(const int& NId, const TStr& attr) const {
   else return VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)];
 }
 
-// Avery
+
 TFltV TNEANet::GetFltVAttrDatN(const int& NId, const TStr& attr) const {
   TInt location = CheckDenseOrSparseN(attr);
   if (location != 0) return VecOfFltVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)];
@@ -1467,7 +1462,7 @@ TIntV TNEANet::GetIntVAttrDatE(const int& EId, const TStr& attr) {
   else return VecOfIntHashVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)];
 }
 
-// Avery
+
 TFltV TNEANet::GetFltVAttrDatE(const int& EId, const TStr& attr) {
   TInt location = CheckDenseOrSparseE(attr);
   if (location != 0) return VecOfFltVecVecsE[KeyToIndexTypeE.GetDat(attr).Val2][EdgeH.GetKeyId(EId)];
@@ -1584,7 +1579,7 @@ int TNEANet::AddIntVAttrN(const TStr& attr, TBool UseDense){
   }
   return 0;
 }
-// Avery
+
 int TNEANet::AddFltVAttrN(const TStr& attr, TBool UseDense){
   TInt CurrLen;
   if (UseDense) {

--- a/snap-core/network.cpp
+++ b/snap-core/network.cpp
@@ -216,7 +216,8 @@ bool TNEANet::IsAttrDeletedN(const int& NId, const TStr& attr) const {
   bool StrDel = IsStrAttrDeletedN(NId, attr);
   bool FltDel = IsFltAttrDeletedN(NId, attr);
   bool IntVDel = IsIntVAttrDeletedN(NId, attr);
-  return IntDel || StrDel || FltDel || IntVDel;
+  bool FltVDel = IsFltVAttrDeletedN(NId, attr);
+  return IntDel || StrDel || FltDel || IntVDel || FltVDel;
 }
 
 bool TNEANet::IsIntAttrDeletedN(const int& NId, const TStr& attr) const {
@@ -225,6 +226,10 @@ bool TNEANet::IsIntAttrDeletedN(const int& NId, const TStr& attr) const {
 
 bool TNEANet::IsIntVAttrDeletedN(const int& NId, const TStr& attr) const {
   return NodeAttrIsIntVDeleted(NId, KeyToIndexTypeN.GetI(attr));
+}
+
+bool TNEANet::IsFltVAttrDeletedN(const int& NId, const TStr& attr) const {
+  return NodeAttrIsFltVDeleted(NId, KeyToIndexTypeN.GetI(attr));
 }
 
 bool TNEANet::IsStrAttrDeletedN(const int& NId, const TStr& attr) const {
@@ -416,7 +421,8 @@ bool TNEANet::IsAttrDeletedE(const int& EId, const TStr& attr) const {
   bool IntVDel = IsIntVAttrDeletedE(EId, attr);
   bool StrDel = IsStrAttrDeletedE(EId, attr);
   bool FltDel = IsFltAttrDeletedE(EId, attr);
-  return IntDel || StrDel || FltDel || IntVDel;
+  bool FltVDel = IsFltVAttrDeletedE(EId, attr);
+  return IntDel || StrDel || FltDel || IntVDel || FltVDel;
 }
 
 bool TNEANet::IsIntAttrDeletedE(const int& EId, const TStr& attr) const {
@@ -425,6 +431,10 @@ bool TNEANet::IsIntAttrDeletedE(const int& EId, const TStr& attr) const {
 
 bool TNEANet::IsIntVAttrDeletedE(const int& EId, const TStr& attr) const {
   return EdgeAttrIsIntVDeleted(EId, KeyToIndexTypeE.GetI(attr));
+}
+
+bool TNEANet::IsFltVAttrDeletedE(const int& EId, const TStr& attr) const {
+  return EdgeAttrIsFltVDeleted(EId, KeyToIndexTypeE.GetI(attr));
 }
 
 bool TNEANet::IsStrAttrDeletedE(const int& EId, const TStr& attr) const {
@@ -452,6 +462,12 @@ bool TNEANet::EdgeAttrIsIntDeleted(const int& EId, const TStrIntPrH::TIter& Edge
 bool TNEANet::EdgeAttrIsIntVDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const {
   return (EdgeHI.GetDat().Val1 == IntVType &&
     TIntV() == this->VecOfIntVecVecsE.GetVal(
+    this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EdgeH.GetKeyId(EId)));
+}
+
+bool TNEANet::EdgeAttrIsFltVDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const {
+  return (EdgeHI.GetDat().Val1 == FltVType &&
+    TFltV() == this->VecOfFltVecVecsE.GetVal(
     this->KeyToIndexTypeE.GetDat(EdgeHI.GetKey()).Val2).GetVal(EdgeH.GetKeyId(EId)));
 }
 
@@ -1417,9 +1433,9 @@ int TNEANet::DelAttrDatN(const int& NId, const TStr& attr) {
     TInt location = CheckDenseOrSparseN(attr);
     if (location == 0) VecOfIntHashVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)] = TIntV();
     else VecOfIntVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)] = TIntV();
-  } else if (vecType ==FltVType) { // added by Avery
-    TInt location = CheckDenseOrSparseN(attr);
-    IAssertR(location != 0, TStr::Fmt("Sparse representation not implemented yet!", NId, attr.CStr())); // not sure about this
+  } else if (vecType == FltVType) { // added by Avery
+    // TInt location = CheckDenseOrSparseN(attr);
+    // IAssertR(location != 0, TStr::Fmt("Sparse representation not implemented yet!", NId, attr.CStr())); // not sure about this
     VecOfFltVecVecsN[KeyToIndexTypeN.GetDat(attr).Val2][NodeH.GetKeyId(NId)] = TFltV();
   } else {
     return -1;

--- a/snap-core/network.cpp
+++ b/snap-core/network.cpp
@@ -139,6 +139,36 @@ void TNEANet::IntVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TI
   }
 }
 
+// Avery
+void TNEANet::FltVAttrNameNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TStrV& Names) const {
+  Names = TVec<TStr>();
+  while (!NodeHI.IsEnd()) {
+    if (NodeHI.GetDat().Val1 == FltVType) {
+      Names.Add(NodeHI.GetKey());
+    }
+    NodeHI++;
+  }  
+}
+
+// Avery
+void TNEANet::FltVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TFltV>& Values) const {
+  Values = TVec<TFltV>();
+  while (!NodeHI.IsEnd()) {
+    if (NodeHI.GetDat().Val1 == FltVType) {
+      TInt index = NodeHI.GetDat().Val2;
+      TStr attr =  NodeHI.GetKey();
+      TInt loc = CheckDenseOrSparseN(attr);
+      if (loc == 1) {
+        TFltV val = this->VecOfFltVecVecsN.GetVal(index).GetVal(NodeH.GetKeyId(NId));
+        if (val.Len() != 0) Values.Add(val);
+      } else {
+        // not implemented yet
+      }
+    }
+    NodeHI++;
+  }
+}
+
 void TNEANet::StrAttrNameNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TStrV& Names) const {
   Names = TVec<TStr>();
   while (!NodeHI.IsEnd()) {
@@ -226,6 +256,14 @@ bool TNEANet::NodeAttrIsIntVDeleted(const int& NId, const TStrIntPrH::TIter& Nod
     return false;
   }
   return (TIntV() == this->VecOfIntVecVecsN.GetVal(
+    this->KeyToIndexTypeN.GetDat(NodeHI.GetKey()).Val2).GetVal(NodeH.GetKeyId(NId)));
+}
+
+bool TNEANet::NodeAttrIsFltVDeleted(const int& NId, const TStrIntPrH::TIter& NodeHI) const {
+  if (NodeHI.GetDat().Val1 != FltVType) {
+    return false;
+  }
+  return (TFltV() == this->VecOfFltVecVecsN.GetVal(
     this->KeyToIndexTypeN.GetDat(NodeHI.GetKey()).Val2).GetVal(NodeH.GetKeyId(NId)));
 }
 
@@ -1446,7 +1484,7 @@ int TNEANet::AddIntVAttrN(const TStr& attr, TBool UseDense){
   }
   return 0;
 }
-
+// Avery
 int TNEANet::AddFltVAttrN(const TStr& attr, TBool UseDense){
   TInt CurrLen;
   if (UseDense) {

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -2287,8 +2287,8 @@ public:
       if (location == 1) {
         HI = VecOfFltVecVecsN[index].BegI();
       } else {
-        // IsDense = false;
-        // HHI = VecOfIntHashVecsN[index].BegI();
+        IsDense = false;
+        HHI = VecOfFltHashVecsN[index].BegI();
       }
     }
     return TAFltVI(HI, HHI, attr, false, this, IsDense);
@@ -2305,7 +2305,7 @@ public:
         HI = VecOfFltVecVecsN[index].EndI();
       } else {
         IsDense = false;
-        // HHI = VecOfIntHashVecsN[index].EndI();
+        HHI = VecOfFltHashVecsN[index].EndI();
       }
     }
     return TAFltVI(HI, HHI, attr, false, this, IsDense);
@@ -2323,8 +2323,8 @@ public:
       if (location == 1) {
         HI = VecOfFltVecVecsN[index].GetI(NodeH.GetKeyId(NId));
       } else {
-        // IsDense = false;
-        // HHI = VecOfIntHashVecsN[index].GetI(NodeH.GetKeyId(NId));
+        IsDense = false;
+        HHI = VecOfFltHashVecsN[index].GetI(NodeH.GetKeyId(NId));
       }
     }
     return TAFltVI(HI, HHI, attr, false, this, IsDense);
@@ -2535,8 +2535,8 @@ public:
       if (location == 1) {
         HI = VecOfFltVecVecsE[index].BegI();
       } else {
-        // IsDense = false;
-        // HHI = VecOfIntHashVecsE[index].BegI();
+        IsDense = false;
+        HHI = VecOfFltHashVecsE[index].BegI();
       }
     }
     return TAFltVI(HI, HHI, attr, true, this, IsDense);
@@ -2552,8 +2552,8 @@ public:
       if (location == 1) {
         HI = VecOfFltVecVecsE[index].EndI();
       } else {
-        // IsDense = false;
-        // HHI = VecOfIntHashVecsE[index].EndI();
+        IsDense = false;
+        HHI = VecOfFltHashVecsE[index].EndI();
       }
     }
     return TAFltVI(HI, HHI, attr, true, this, IsDense);
@@ -2569,8 +2569,8 @@ public:
       if (location == 1) {
         HI = VecOfFltVecVecsE[index].GetI(EdgeH.GetKeyId(EId));
       } else {
-        // IsDense = false;
-        // HHI = VecOfIntHashVecsE[index].GetI(EdgeH.GetKeyId(EId));
+        IsDense = false;
+        HHI = VecOfFltHashVecsE[index].GetI(EdgeH.GetKeyId(EId));
       }
     }
     return TAFltVI(HI, HHI, attr, true, this, IsDense);

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1878,8 +1878,9 @@ protected:
   TVec<TStrV> VecOfStrVecsN, VecOfStrVecsE;
   TVec<TFltV> VecOfFltVecsN, VecOfFltVecsE;
   TVec<TVec<TIntV> > VecOfIntVecVecsN, VecOfIntVecVecsE;
+  TVec<TVec<TFltV> > VecOfFltVecVecsN, VecOfFltVecVecsE; // added by Avery
   TVec<THash<TInt, TIntV> > VecOfIntHashVecsN, VecOfIntHashVecsE;
-  enum { IntType, StrType, FltType, IntVType };
+  enum { IntType, StrType, FltType, IntVType, FltVType };
 
   TAttr SAttrN;
   TAttr SAttrE;
@@ -1938,6 +1939,7 @@ public:
     StrDefaultsN(), StrDefaultsE(), FltDefaultsN(), FltDefaultsE(),
     VecOfIntVecsN(), VecOfIntVecsE(), VecOfStrVecsN(), VecOfStrVecsE(),
     VecOfFltVecsN(), VecOfFltVecsE(),  VecOfIntVecVecsN(), VecOfIntVecVecsE(),
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
     VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE(){ }
   /// Constructor that reserves enough memory for a graph of nodes and edges.
   explicit TNEANet(const int& Nodes, const int& Edges) : CRef(),
@@ -1945,6 +1947,7 @@ public:
     IntDefaultsN(), IntDefaultsE(), StrDefaultsN(), StrDefaultsE(),
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
     VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
     VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE()
     { Reserve(Nodes, Edges); }
   TNEANet(const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
@@ -1952,13 +1955,16 @@ public:
     IntDefaultsN(), IntDefaultsE(), StrDefaultsN(), StrDefaultsE(),
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
     VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
     VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE() { }
   /// Constructor for loading the graph from a (binary) stream SIn.
   TNEANet(TSIn& SIn) : MxNId(SIn), MxEId(SIn), NodeH(SIn), EdgeH(SIn),
     KeyToIndexTypeN(SIn), KeyToIndexTypeE(SIn), KeyToDenseN(SIn), KeyToDenseE(SIn), IntDefaultsN(SIn), IntDefaultsE(SIn),
     StrDefaultsN(SIn), StrDefaultsE(SIn), FltDefaultsN(SIn), FltDefaultsE(SIn),
     VecOfIntVecsN(SIn), VecOfIntVecsE(SIn), VecOfStrVecsN(SIn),VecOfStrVecsE(SIn),
-    VecOfFltVecsN(SIn), VecOfFltVecsE(SIn), VecOfIntVecVecsN(SIn), VecOfIntVecVecsE(SIn), VecOfIntHashVecsN(SIn), VecOfIntHashVecsE(SIn),
+    VecOfFltVecsN(SIn), VecOfFltVecsE(SIn), VecOfIntVecVecsN(SIn), VecOfIntVecVecsE(SIn), 
+    VecOfFltVecVecsN(SIn), VecOfFltVecVecsE(SIn), // added by Avery
+    VecOfIntHashVecsN(SIn), VecOfIntHashVecsE(SIn),
     SAttrN(SIn), SAttrE(SIn) { }
 protected:
   TNEANet(const TNEANet& Graph, bool modeSubGraph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
@@ -1966,14 +1972,18 @@ protected:
     IntDefaultsN(Graph.IntDefaultsN), IntDefaultsE(Graph.IntDefaultsE), StrDefaultsN(Graph.StrDefaultsN), StrDefaultsE(Graph.StrDefaultsE),
     FltDefaultsN(Graph.FltDefaultsN), FltDefaultsE(Graph.FltDefaultsE), VecOfIntVecsN(Graph.VecOfIntVecsN), VecOfIntVecsE(Graph.VecOfIntVecsE),
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
-    VecOfIntVecVecsN(), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), VecOfIntHashVecsN(), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE) { }
+    VecOfIntVecVecsN(), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), 
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), // added by Avery
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE) { }
   TNEANet(bool copyAll, const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
     NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(Graph.KeyToIndexTypeN), KeyToIndexTypeE(Graph.KeyToIndexTypeE), KeyToDenseN(Graph.KeyToDenseN), KeyToDenseE(Graph.KeyToDenseE),
     IntDefaultsN(Graph.IntDefaultsN), IntDefaultsE(Graph.IntDefaultsE), StrDefaultsN(Graph.StrDefaultsN), StrDefaultsE(Graph.StrDefaultsE),
     FltDefaultsN(Graph.FltDefaultsN), FltDefaultsE(Graph.FltDefaultsE), VecOfIntVecsN(Graph.VecOfIntVecsN), VecOfIntVecsE(Graph.VecOfIntVecsE),
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
-    VecOfIntVecVecsN(Graph.VecOfIntVecVecsN), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), VecOfIntHashVecsN(Graph.VecOfIntHashVecsN), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE), SAttrN(Graph.SAttrN), SAttrE(Graph.SAttrE) { }
-  // virtual ~TNEANet() { }
+    VecOfIntVecVecsN(Graph.VecOfIntVecVecsN), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), 
+    VecOfFltVecVecsN(Graph.VecOfFltVecVecsN), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), // added by Avery
+    VecOfIntHashVecsN(Graph.VecOfIntHashVecsN), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE), SAttrN(Graph.SAttrN), SAttrE(Graph.SAttrE) { }
+  // virtual ~TNEANet() { }cd ..
 public:
   /// Saves the graph to a (binary) stream SOut. Expects data structures for sparse attributes.
   void Save(TSOut& SOut) const {
@@ -1987,6 +1997,7 @@ public:
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
     VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut);
+    VecOfFltVecVecsN.Save(SOut); VecOfFltVecVecsE.Save(SOut); // added by Avery
     VecOfIntHashVecsN.Save(SOut); VecOfIntHashVecsE.Save(SOut); 
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Saves the graph to a (binary) stream SOut. Available for backwards compatibility.
@@ -2010,6 +2021,7 @@ public:
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
     VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut); 
+    VecOfFltVecVecsN.Save(SOut); VecOfFltVecVecsE.Save(SOut); // added by Avery
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Static cons returns pointer to graph. Ex: PNEANet Graph=TNEANet::New().
   static PNEANet New() { return PNEANet(new TNEANet()); }
@@ -2028,7 +2040,7 @@ public:
     Graph->FltDefaultsN.Load(SIn); Graph->FltDefaultsE.Load(SIn);
     Graph->VecOfIntVecsN.Load(SIn); Graph->VecOfIntVecsE.Load(SIn);
     Graph->VecOfStrVecsN.Load(SIn); Graph->VecOfStrVecsE.Load(SIn);
-    Graph->VecOfFltVecsN.Load(SIn); Graph->VecOfFltVecsE.Load(SIn);
+    Graph->VecOfFltVecsN.Load(SIn); Graph->VecOfFltVecsE.Load(SIn); 
     return Graph;
   }
 
@@ -2045,6 +2057,7 @@ public:
     Graph->VecOfStrVecsN.Load(SIn); Graph->VecOfStrVecsE.Load(SIn);
     Graph->VecOfFltVecsN.Load(SIn); Graph->VecOfFltVecsE.Load(SIn);
     Graph->VecOfIntVecVecsN.Load(SIn); Graph->VecOfIntVecVecsE.Load(SIn);
+    Graph->VecOfFltVecVecsN.Load(SIn); Graph->VecOfFltVecVecsE.Load(SIn); // Avery
     Graph->SAttrN.Load(SIn); Graph->SAttrE.Load(SIn);
     return Graph;
   }
@@ -2239,6 +2252,15 @@ public:
     IntVAttrValueNI(NId, KeyToIndexTypeN.BegI(), Values);}
   void IntVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TIntV>& Values) const;
 
+  /// Avery: Returns a vector of int attr names for node NId.
+  void FltVAttrNameNI(const TInt& NId, TStrV& Names) const {
+    FltVAttrNameNI(NId, KeyToIndexTypeN.BegI(), Names);}
+  void FltVAttrNameNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TStrV& Names) const;
+  /// Avery: Returns a vector of attr values for node NId.
+  void FltVAttrValueNI(const TInt& NId, TVec<TFltV>& Values) const {
+    FltVAttrValueNI(NId, KeyToIndexTypeN.BegI(), Values);}
+  void FltVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TFltV>& Values) const;
+
 
   /// Returns a vector of str attr names for node NId.
   void StrAttrNameNI(const TInt& NId, TStrV& Names) const {
@@ -2283,6 +2305,15 @@ public:
   void IntVAttrValueEI(const TInt& EId, TVec<TIntV>& Values) const {
     IntVAttrValueEI(EId, KeyToIndexTypeE.BegI(), Values);}
   void IntVAttrValueEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TVec<TIntV>& Values) const;
+
+  /// Avery: Returns a vector of flt attr names for edge EId.
+  void FltVAttrNameEI(const TInt& EId, TStrV& Names) const {
+    FltVAttrNameEI(EId, KeyToIndexTypeE.BegI(), Names);}
+  void FltVAttrNameEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TStrV& Names) const;
+  /// Avery: Returns a vector of attr values for edge EId.
+  void FltVAttrValueEI(const TInt& EId, TVec<TFltV>& Values) const {
+    FltVAttrValueEI(EId, KeyToIndexTypeE.BegI(), Values);}
+  void FltVAttrValueEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TVec<TFltV>& Values) const;
 
 
   /// Returns a vector of str attr names for node NId.
@@ -2443,6 +2474,7 @@ public:
     StrDefaultsN.Clr(); StrDefaultsE.Clr(); FltDefaultsN.Clr(); FltDefaultsE.Clr();
     VecOfIntVecsN.Clr(); VecOfIntVecsE.Clr(); VecOfStrVecsN.Clr(); VecOfStrVecsE.Clr();
     VecOfFltVecsN.Clr(); VecOfFltVecsE.Clr(); VecOfIntVecVecsN.Clr(); VecOfIntVecVecsE.Clr(); 
+    VecOfFltVecVecsN.Clr(); VecOfFltVecVecsE.Clr(); // added by Avery
     SAttrN.Clr(); SAttrE.Clr();}
   /// Reserves memory for a graph of Nodes nodes and Edges edges.
   void Reserve(const int& Nodes, const int& Edges) {
@@ -2466,12 +2498,28 @@ public:
   /// Attribute based add function for attr to IntV value. ##TNEANet::AddIntVAttrDatN
   int AddIntVAttrDatN(const TNodeI& NodeI, const TIntV& value, const TStr& attr) { return AddIntVAttrDatN(NodeI.GetId(), value, attr); }
   int AddIntVAttrDatN(const int& NId, const TIntV& value, const TStr& attr, TBool UseDense=true);
+  /// Avery: Attribute based add function for attr to IntV value. ##TNEANet::AddIntVAttrDatN
+  int AddFltVAttrDatN(const TNodeI& NodeI, const TFltV& value, const TStr& attr) { return AddFltVAttrDatN(NodeI.GetId(), value, attr); }
+  int AddFltVAttrDatN(const int& NId, const TFltV& value, const TStr& attr, TBool UseDense=true);
+
+
+
   /// Appends value onto the TIntV attribute for the given node.
   int AppendIntVAttrDatN(const TNodeI& NodeI, const TInt& value, const TStr& attr) { return AppendIntVAttrDatN(NodeI.GetId(), value, attr); }
   int AppendIntVAttrDatN(const int& NId, const TInt& value, const TStr& attr, TBool UseDense=true);
   /// Deletes value from the TIntV attribute for the given node.
   int DelFromIntVAttrDatN(const TNodeI& NodeI, const TInt& value, const TStr& attr) { return DelFromIntVAttrDatN(NodeI.GetId(), value, attr); }
   int DelFromIntVAttrDatN(const int& NId, const TInt& value, const TStr& attr);
+
+  /// Appends value onto the TFltV attribute for the given node.
+  int AppendFltVAttrDatN(const TNodeI& NodeI, const TFlt& value, const TStr& attr) { return AppendFltVAttrDatN(NodeI.GetId(), value, attr); }
+  int AppendFltVAttrDatN(const int& NId, const TFlt& value, const TStr& attr, TBool UseDense=true);
+  /// Deletes value from the TFltV attribute for the given node.
+  int DelFromFltVAttrDatN(const TNodeI& NodeI, const TFlt& value, const TStr& attr) { return DelFromFltVAttrDatN(NodeI.GetId(), value, attr); }
+  int DelFromFltVAttrDatN(const int& NId, const TFlt& value, const TStr& attr);
+
+  
+
   /// Attribute based add function for attr to Int value. ##TNEANet::AddIntAttrDatE
   int AddIntAttrDatE(const TEdgeI& EdgeI, const TInt& value, const TStr& attr) { return AddIntAttrDatE(EdgeI.GetId(), value, attr); }
   int AddIntAttrDatE(const int& EId, const TInt& value, const TStr& attr);
@@ -2481,12 +2529,25 @@ public:
   /// Attribute based add function for attr to Flt value. ##TNEANet::AddFltAttrDatE
   int AddFltAttrDatE(const TEdgeI& EdgeI, const TFlt& value, const TStr& attr) { return AddFltAttrDatE(EdgeI.GetId(), value, attr); }
   int AddFltAttrDatE(const int& EId, const TFlt& value, const TStr& attr);
+
+
   /// Attribute based add function for attr to IntV value. ##TNEANet::AddIntVAttrDatE
   int AddIntVAttrDatE(const TEdgeI& EdgeI, const TIntV& value, const TStr& attr) { return AddIntVAttrDatE(EdgeI.GetId(), value, attr); }
   int AddIntVAttrDatE(const int& EId, const TIntV& value, const TStr& attr, TBool UseDense=true);
   /// Appends value onto the TIntV attribute for the given node.
   int AppendIntVAttrDatE(const TEdgeI& EdgeI, const TInt& value, const TStr& attr) { return AppendIntVAttrDatE(EdgeI.GetId(), value, attr); }
   int AppendIntVAttrDatE(const int& EId, const TInt& value, const TStr& attr, TBool UseDense=true);
+
+  /// Avery: Attribute based add function for attr to TFlt value. ##TNEANet::AddTFltAttrDatE
+  int AddFltVAttrDatE(const TEdgeI& EdgeI, const TFltV& value, const TStr& attr) { return AddFltVAttrDatE(EdgeI.GetId(), value, attr); }
+  int AddFltVAttrDatE(const int& EId, const TFltV& value, const TStr& attr, TBool UseDense=true);
+  /// Avery: Appends value onto the TFlt attribute for the given node.
+  int AppendFltVAttrDatE(const TEdgeI& EdgeI, const TFlt& value, const TStr& attr) { return AppendFltVAttrDatE(EdgeI.GetId(), value, attr); }
+  int AppendFltVAttrDatE(const int& EId, const TFlt& value, const TStr& attr, TBool UseDense=true);
+
+
+
+
   /// Gets the value of int attr from the node attr value vector.
   TInt GetIntAttrDatN(const TNodeI& NodeI, const TStr& attr) { return GetIntAttrDatN(NodeI.GetId(), attr); }
   TInt GetIntAttrDatN(const int& NId, const TStr& attr);
@@ -2500,6 +2561,10 @@ public:
   /// Gets the value of the intv attr from the node attr value vector.
   TIntV GetIntVAttrDatN(const TNodeI& NodeI, const TStr& attr) const { return GetIntVAttrDatN(NodeI.GetId(), attr); }
   TIntV GetIntVAttrDatN(const int& NId, const TStr& attr) const;
+
+  /// Avery: Gets the value of the intv attr from the node attr value vector.  
+  TFltV GetFltVAttrDatN(const TNodeI& NodeI, const TStr& attr) const { return GetFltVAttrDatN(NodeI.GetId(), attr); }
+  TFltV GetFltVAttrDatN(const int& NId, const TStr& attr) const;
 
   /// Gets the index of the node attr value vector specified by \c attr (same as GetAttrIndN for compatibility reasons).
   int GetIntAttrIndN(const TStr& attr);
@@ -2533,6 +2598,10 @@ public:
   /// Gets the value of the intv attr from the edge attr value vector.
   TIntV GetIntVAttrDatE(const TEdgeI& EdgeI, const TStr& attr) { return GetIntVAttrDatE(EdgeI.GetId(), attr); }
   TIntV GetIntVAttrDatE(const int& EId, const TStr& attr);
+
+  /// Avery: Gets the value of the fltv attr from the edge attr value vector.
+  TFltV GetFltVAttrDatE(const TEdgeI& EdgeI, const TStr& attr) { return GetFltVAttrDatE(EdgeI.GetId(), attr); }
+  TFltV GetFltVAttrDatE(const int& EId, const TStr& attr);
 
   /// Gets the index of the edge attr value vector specified by \c attr (same as GetAttrIndE for compatibility reasons).
   int GetIntAttrIndE(const TStr& attr);
@@ -2570,6 +2639,9 @@ public:
   /// Adds a new IntV node attribute to the hashmap.
   int AddIntVAttrN(const TStr& attr, TBool UseDense=true);
 
+  /// Avery: Adds a new FltV node attribute to the hashmap.
+  int AddFltVAttrN(const TStr& attr, TBool UseDense=true);
+
   /// Adds a new Int edge attribute to the hashmap.
   int AddIntAttrE(const TStr& attr, TInt defaultValue=TInt::Mn);
   /// Adds a new Str edge attribute to the hashmap.
@@ -2578,6 +2650,9 @@ public:
   int AddFltAttrE(const TStr& attr, TFlt defaultValue=TFlt::Mn);
   /// Adds a new IntV edge attribute to the hashmap.
   int AddIntVAttrE(const TStr& attr, TBool UseDense=true);
+
+  /// Avery: Adds a new IntV edge attribute to the hashmap.
+  int AddFltVAttrE(const TStr& attr, TBool UseDense=true);
 
   /// Removes all the values for node attr.
   int DelAttrN(const TStr& attr);
@@ -2590,6 +2665,8 @@ public:
   bool IsIntAttrDeletedN(const int& NId, const TStr& attr) const;
   /// Returns true if IntV \c attr exists for node \c NId and is an empty vector.
   bool IsIntVAttrDeletedN(const int& NId, const TStr& attr) const;
+  /// Avery: Returns true if FltV \c attr exists for node \c NId and is an empty vector.
+  bool IsFltVAttrDeletedN(const int& NId, const TStr& attr) const;
   /// Returns true if Str \c attr exists for node \c NId and has default value.
   bool IsStrAttrDeletedN(const int& NId, const TStr& attr) const;
   /// Returns true if Flt \c attr exists for node \c NId and has default value.
@@ -2601,6 +2678,8 @@ public:
   bool NodeAttrIsIntDeleted(const int& NId, const TStrIntPrH::TIter& NodeHI) const;
   /// Returns true if NId attr deleted value for current node int vector attr iterator.
   bool NodeAttrIsIntVDeleted(const int& NId, const TStrIntPrH::TIter& NodeHI) const;
+  /// Returns true if NId attr deleted value for current node int vector attr iterator.
+  bool NodeAttrIsFltVDeleted(const int& NId, const TStrIntPrH::TIter& NodeHI) const;
   /// Returns true if NId attr deleted value for current node str attr iterator.
   bool NodeAttrIsStrDeleted(const int& NId, const TStrIntPrH::TIter& NodeHI) const;
   /// Returns true if NId attr deleted value for current node flt attr iterator.
@@ -2612,6 +2691,8 @@ public:
   bool IsIntAttrDeletedE(const int& EId, const TStr& attr) const;
   /// Returns true if IntV \c attr exists for edge \c EId and is an empty vector.
   bool IsIntVAttrDeletedE(const int& EId, const TStr& attr) const;
+  /// Avery: Returns true if FltV \c attr exists for edge \c EId and is an empty vector.
+  bool IsFltVAttrDeletedE(const int& EId, const TStr& attr) const;
   /// Returns true if Str \c attr exists for edge \c NId and has default value.
   bool IsStrAttrDeletedE(const int& EId, const TStr& attr) const;
   /// Returns true if Flt \c attr exists for edge \c NId and has default value.
@@ -2623,6 +2704,8 @@ public:
   bool EdgeAttrIsIntDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
   /// Returns true if EId attr deleted for current edge int vector attr iterator.
   bool EdgeAttrIsIntVDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
+  /// Avery: Returns true if EId attr deleted for current edge flt vector attr iterator.
+  bool EdgeAttrIsFltVDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
   /// Returns true if EId attr deleted for current edge str attr iterator.
   bool EdgeAttrIsStrDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
   /// Returns true if EId attr deleted for current edge flt attr iterator.
@@ -2759,6 +2842,7 @@ public:
     return GetSAttrVN(NodeI.GetId(), AttrType, AttrV);
   }
 
+  // Avery: unsure about these
   /// Gets a list of all nodes that have a sparse attribute with name \c AttrName.
   int GetIdVSAttrN(const TStr& AttrName, TIntV& IdV) const;
   /// Gets a list of all nodes that have a sparse attribute with id \c AttrId.
@@ -2876,6 +2960,7 @@ public:
     return GetSAttrVE(EdgeI.GetId(), AttrType, AttrV);
   }
 
+  // Avery: unsure
   /// Gets a list of all edges that have a sparse attribute with name \c AttrName.
   int GetIdVSAttrE(const TStr& AttrName, TIntV& IdV) const;
   /// Gets a list of all edges that have a sparse attribute with id \c AttrId.

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1903,7 +1903,7 @@ protected:
   TVec<TStrV> VecOfStrVecsN, VecOfStrVecsE;
   TVec<TFltV> VecOfFltVecsN, VecOfFltVecsE;
   TVec<TVec<TIntV> > VecOfIntVecVecsN, VecOfIntVecVecsE;
-  TVec<TVec<TFltV> > VecOfFltVecVecsN, VecOfFltVecVecsE; // added by Avery
+  TVec<TVec<TFltV> > VecOfFltVecVecsN, VecOfFltVecVecsE; 
   TVec<THash<TInt, TIntV> > VecOfIntHashVecsN, VecOfIntHashVecsE;
   TVec<THash<TInt, TFltV> > VecOfFltHashVecsN, VecOfFltHashVecsE;
   enum { IntType, StrType, FltType, IntVType, FltVType };
@@ -1965,9 +1965,9 @@ public:
     StrDefaultsN(), StrDefaultsE(), FltDefaultsN(), FltDefaultsE(),
     VecOfIntVecsN(), VecOfIntVecsE(), VecOfStrVecsN(), VecOfStrVecsE(),
     VecOfFltVecsN(), VecOfFltVecsE(),  VecOfIntVecVecsN(), VecOfIntVecVecsE(),
-    VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(), 
     VecOfIntHashVecsN(), VecOfIntHashVecsE(), 
-    VecOfFltHashVecsN(), VecOfFltHashVecsE(), // added by Avery
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(), 
     SAttrN(), SAttrE(){ }
   /// Constructor that reserves enough memory for a graph of nodes and edges.
   explicit TNEANet(const int& Nodes, const int& Edges) : CRef(),
@@ -1975,9 +1975,9 @@ public:
     IntDefaultsN(), IntDefaultsE(), StrDefaultsN(), StrDefaultsE(),
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
     VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
-    VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(), 
     VecOfIntHashVecsN(), VecOfIntHashVecsE(), 
-    VecOfFltHashVecsN(), VecOfFltHashVecsE(), // added by Avery
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(), 
     SAttrN(), SAttrE()
     { Reserve(Nodes, Edges); }
   TNEANet(const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
@@ -1985,9 +1985,9 @@ public:
     IntDefaultsN(), IntDefaultsE(), StrDefaultsN(), StrDefaultsE(),
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
     VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
-    VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(), 
     VecOfIntHashVecsN(), VecOfIntHashVecsE(), 
-    VecOfFltHashVecsN(), VecOfFltHashVecsE(), // added by Avery
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(), 
     SAttrN(), SAttrE() { }
   /// Constructor for loading the graph from a (binary) stream SIn.
   TNEANet(TSIn& SIn) : MxNId(SIn), MxEId(SIn), NodeH(SIn), EdgeH(SIn),
@@ -1995,9 +1995,9 @@ public:
     StrDefaultsN(SIn), StrDefaultsE(SIn), FltDefaultsN(SIn), FltDefaultsE(SIn),
     VecOfIntVecsN(SIn), VecOfIntVecsE(SIn), VecOfStrVecsN(SIn),VecOfStrVecsE(SIn),
     VecOfFltVecsN(SIn), VecOfFltVecsE(SIn), VecOfIntVecVecsN(SIn), VecOfIntVecVecsE(SIn), 
-    VecOfFltVecVecsN(SIn), VecOfFltVecVecsE(SIn), // added by Avery
+    VecOfFltVecVecsN(SIn), VecOfFltVecVecsE(SIn), 
     VecOfIntHashVecsN(SIn), VecOfIntHashVecsE(SIn),
-    VecOfFltHashVecsN(SIn), VecOfFltHashVecsE(SIn), // added by Avery
+    VecOfFltHashVecsN(SIn), VecOfFltHashVecsE(SIn), 
     SAttrN(SIn), SAttrE(SIn) { }
 protected:
   TNEANet(const TNEANet& Graph, bool modeSubGraph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
@@ -2006,9 +2006,9 @@ protected:
     FltDefaultsN(Graph.FltDefaultsN), FltDefaultsE(Graph.FltDefaultsE), VecOfIntVecsN(Graph.VecOfIntVecsN), VecOfIntVecsE(Graph.VecOfIntVecsE),
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
     VecOfIntVecVecsN(), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), 
-    VecOfFltVecVecsN(), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), // added by Avery
+    VecOfFltVecVecsN(), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), 
     VecOfIntHashVecsN(), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE),
-    VecOfFltHashVecsN(), VecOfFltHashVecsE(Graph.VecOfFltHashVecsE) // added by Avery
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(Graph.VecOfFltHashVecsE) 
      { }
   TNEANet(bool copyAll, const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
     NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(Graph.KeyToIndexTypeN), KeyToIndexTypeE(Graph.KeyToIndexTypeE), KeyToDenseN(Graph.KeyToDenseN), KeyToDenseE(Graph.KeyToDenseE),
@@ -2016,9 +2016,9 @@ protected:
     FltDefaultsN(Graph.FltDefaultsN), FltDefaultsE(Graph.FltDefaultsE), VecOfIntVecsN(Graph.VecOfIntVecsN), VecOfIntVecsE(Graph.VecOfIntVecsE),
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
     VecOfIntVecVecsN(Graph.VecOfIntVecVecsN), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), 
-    VecOfFltVecVecsN(Graph.VecOfFltVecVecsN), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), // added by Avery
+    VecOfFltVecVecsN(Graph.VecOfFltVecVecsN), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), 
     VecOfIntHashVecsN(Graph.VecOfIntHashVecsN), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE), 
-    VecOfFltHashVecsN(Graph.VecOfFltHashVecsN), VecOfFltHashVecsE(Graph.VecOfFltHashVecsE), // added by Avery
+    VecOfFltHashVecsN(Graph.VecOfFltHashVecsN), VecOfFltHashVecsE(Graph.VecOfFltHashVecsE), 
     SAttrN(Graph.SAttrN), SAttrE(Graph.SAttrE) { }
   // virtual ~TNEANet() { }cd ..
 public:
@@ -2034,9 +2034,9 @@ public:
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
     VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut);
-    VecOfFltVecVecsN.Save(SOut); VecOfFltVecVecsE.Save(SOut); // added by Avery
+    VecOfFltVecVecsN.Save(SOut); VecOfFltVecVecsE.Save(SOut); 
     VecOfIntHashVecsN.Save(SOut); VecOfIntHashVecsE.Save(SOut); 
-    VecOfFltHashVecsN.Save(SOut); VecOfFltHashVecsE.Save(SOut); // added by Avery
+    VecOfFltHashVecsN.Save(SOut); VecOfFltHashVecsE.Save(SOut); 
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Saves the graph to a (binary) stream SOut. Available for backwards compatibility.
   void Save_V1(TSOut& SOut) const {
@@ -2059,7 +2059,7 @@ public:
     VecOfStrVecsN.Save(SOut); VecOfStrVecsE.Save(SOut);
     VecOfFltVecsN.Save(SOut); VecOfFltVecsE.Save(SOut);
     VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut); 
-    VecOfFltVecVecsN.Save(SOut); VecOfFltVecVecsE.Save(SOut); // added by Avery
+    VecOfFltVecVecsN.Save(SOut); VecOfFltVecVecsE.Save(SOut); 
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Static cons returns pointer to graph. Ex: PNEANet Graph=TNEANet::New().
   static PNEANet New() { return PNEANet(new TNEANet()); }
@@ -2095,7 +2095,7 @@ public:
     Graph->VecOfStrVecsN.Load(SIn); Graph->VecOfStrVecsE.Load(SIn);
     Graph->VecOfFltVecsN.Load(SIn); Graph->VecOfFltVecsE.Load(SIn);
     Graph->VecOfIntVecVecsN.Load(SIn); Graph->VecOfIntVecVecsE.Load(SIn);
-    Graph->VecOfFltVecVecsN.Load(SIn); Graph->VecOfFltVecVecsE.Load(SIn); // Avery
+    Graph->VecOfFltVecVecsN.Load(SIn); Graph->VecOfFltVecVecsE.Load(SIn); 
     Graph->SAttrN.Load(SIn); Graph->SAttrE.Load(SIn);
     return Graph;
   }
@@ -2109,7 +2109,7 @@ public:
     return PNEANet(Network);
   }
 
-  void ConvertToSparse() { // TODO
+  void ConvertToSparse() { 
     TInt VecLength = VecOfIntVecVecsN.Len();
     THash<TStr, TIntPr>::TIter iter;
     if (VecLength != 0) {
@@ -2276,7 +2276,7 @@ public:
     return TAIntVI(HI, HHI, attr, false, this, IsDense);
   }
 
-  /// Returns an iterator referring to the first node's int attribute.
+  /// Returns an iterator referring to the first node's flt attribute.
   TAFltVI BegNAFltVI(const TStr& attr) const {
     TVec<TFltV>::TIter HI = NULL;
     THash<TInt, TFltV>::TIter HHI;
@@ -2378,11 +2378,11 @@ public:
     IntVAttrValueNI(NId, KeyToIndexTypeN.BegI(), Values);}
   void IntVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TIntV>& Values) const;
 
-  /// Avery: Returns a vector of int attr names for node NId.
+  /// Returns a vector of flt attr names for node NId.
   void FltVAttrNameNI(const TInt& NId, TStrV& Names) const {
     FltVAttrNameNI(NId, KeyToIndexTypeN.BegI(), Names);}
   void FltVAttrNameNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TStrV& Names) const;
-  /// Avery: Returns a vector of attr values for node NId.
+  /// Returns a vector of flt values for node NId.
   void FltVAttrValueNI(const TInt& NId, TVec<TFltV>& Values) const {
     FltVAttrValueNI(NId, KeyToIndexTypeN.BegI(), Values);}
   void FltVAttrValueNI(const TInt& NId, TStrIntPrH::TIter NodeHI, TVec<TFltV>& Values) const;
@@ -2432,11 +2432,11 @@ public:
     IntVAttrValueEI(EId, KeyToIndexTypeE.BegI(), Values);}
   void IntVAttrValueEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TVec<TIntV>& Values) const;
 
-  /// Avery: Returns a vector of flt attr names for edge EId.
+  /// Returns a vector of flt attr names for edge EId.
   void FltVAttrNameEI(const TInt& EId, TStrV& Names) const {
     FltVAttrNameEI(EId, KeyToIndexTypeE.BegI(), Names);}
   void FltVAttrNameEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TStrV& Names) const;
-  /// Avery: Returns a vector of attr values for edge EId.
+  /// Returns a vector of attr values for edge EId.
   void FltVAttrValueEI(const TInt& EId, TVec<TFltV>& Values) const {
     FltVAttrValueEI(EId, KeyToIndexTypeE.BegI(), Values);}
   void FltVAttrValueEI(const TInt& EId, TStrIntPrH::TIter EdgeHI, TVec<TFltV>& Values) const;
@@ -2652,7 +2652,7 @@ public:
     StrDefaultsN.Clr(); StrDefaultsE.Clr(); FltDefaultsN.Clr(); FltDefaultsE.Clr();
     VecOfIntVecsN.Clr(); VecOfIntVecsE.Clr(); VecOfStrVecsN.Clr(); VecOfStrVecsE.Clr();
     VecOfFltVecsN.Clr(); VecOfFltVecsE.Clr(); VecOfIntVecVecsN.Clr(); VecOfIntVecVecsE.Clr(); 
-    VecOfFltVecVecsN.Clr(); VecOfFltVecVecsE.Clr(); // added by Avery
+    VecOfFltVecVecsN.Clr(); VecOfFltVecVecsE.Clr(); 
     SAttrN.Clr(); SAttrE.Clr();}
   /// Reserves memory for a graph of Nodes nodes and Edges edges.
   void Reserve(const int& Nodes, const int& Edges) {
@@ -2664,19 +2664,19 @@ public:
   /// Print the graph in a human readable form to an output stream OutF.
   void Dump(FILE *OutF=stdout) const;
 
-  /// Attribute based add function for attr to Int value. ##TNEANet::AddIntAttrDatN
+  /// Attribute based add function for attr to Int value. 
   int AddIntAttrDatN(const TNodeI& NodeI, const TInt& value, const TStr& attr) { return AddIntAttrDatN(NodeI.GetId(), value, attr); }
   int AddIntAttrDatN(const int& NId, const TInt& value, const TStr& attr);
-  /// Attribute based add function for attr to Str value. ##TNEANet::AddStrAttrDatN
+  /// Attribute based add function for attr to Str value. 
   int AddStrAttrDatN(const TNodeI& NodeI, const TStr& value, const TStr& attr) { return AddStrAttrDatN(NodeI.GetId(), value, attr); }
   int AddStrAttrDatN(const int& NId, const TStr& value, const TStr& attr);
-  /// Attribute based add function for attr to Flt value. ##TNEANet::AddFltAttrDatN
+  /// Attribute based add function for attr to Flt value. 
   int AddFltAttrDatN(const TNodeI& NodeI, const TFlt& value, const TStr& attr) { return AddFltAttrDatN(NodeI.GetId(), value, attr); }
   int AddFltAttrDatN(const int& NId, const TFlt& value, const TStr& attr);
-  /// Attribute based add function for attr to IntV value. ##TNEANet::AddIntVAttrDatN
+  /// Attribute based add function for attr to IntV value. 
   int AddIntVAttrDatN(const TNodeI& NodeI, const TIntV& value, const TStr& attr) { return AddIntVAttrDatN(NodeI.GetId(), value, attr); }
   int AddIntVAttrDatN(const int& NId, const TIntV& value, const TStr& attr, TBool UseDense=true);
-  /// Avery: Attribute based add function for attr to IntV value. ##TNEANet::AddIntVAttrDatN
+  /// Attribute based add function for attr to FltV value.
   int AddFltVAttrDatN(const TNodeI& NodeI, const TFltV& value, const TStr& attr) { return AddFltVAttrDatN(NodeI.GetId(), value, attr); }
   int AddFltVAttrDatN(const int& NId, const TFltV& value, const TStr& attr, TBool UseDense=true);
 
@@ -2716,10 +2716,10 @@ public:
   int AppendIntVAttrDatE(const TEdgeI& EdgeI, const TInt& value, const TStr& attr) { return AppendIntVAttrDatE(EdgeI.GetId(), value, attr); }
   int AppendIntVAttrDatE(const int& EId, const TInt& value, const TStr& attr, TBool UseDense=true);
 
-  /// Avery: Attribute based add function for attr to TFlt value. ##TNEANet::AddTFltAttrDatE
+  /// Attribute based add function for attr to TFltV value. ##TNEANet::AddTFltAttrDatE
   int AddFltVAttrDatE(const TEdgeI& EdgeI, const TFltV& value, const TStr& attr) { return AddFltVAttrDatE(EdgeI.GetId(), value, attr); }
   int AddFltVAttrDatE(const int& EId, const TFltV& value, const TStr& attr, TBool UseDense=true);
-  /// Avery: Appends value onto the TFlt attribute for the given node.
+  /// Appends value onto the TFltV attribute for the given node.
   int AppendFltVAttrDatE(const TEdgeI& EdgeI, const TFlt& value, const TStr& attr) { return AppendFltVAttrDatE(EdgeI.GetId(), value, attr); }
   int AppendFltVAttrDatE(const int& EId, const TFlt& value, const TStr& attr, TBool UseDense=true);
 
@@ -2740,7 +2740,7 @@ public:
   TIntV GetIntVAttrDatN(const TNodeI& NodeI, const TStr& attr) const { return GetIntVAttrDatN(NodeI.GetId(), attr); }
   TIntV GetIntVAttrDatN(const int& NId, const TStr& attr) const;
 
-  /// Avery: Gets the value of the intv attr from the node attr value vector.  
+  /// Gets the value of the fltv attr from the node attr value vector.  
   TFltV GetFltVAttrDatN(const TNodeI& NodeI, const TStr& attr) const { return GetFltVAttrDatN(NodeI.GetId(), attr); }
   TFltV GetFltVAttrDatN(const int& NId, const TStr& attr) const;
 
@@ -2777,7 +2777,7 @@ public:
   TIntV GetIntVAttrDatE(const TEdgeI& EdgeI, const TStr& attr) { return GetIntVAttrDatE(EdgeI.GetId(), attr); }
   TIntV GetIntVAttrDatE(const int& EId, const TStr& attr);
 
-  /// Avery: Gets the value of the fltv attr from the edge attr value vector.
+  /// Gets the value of the fltv attr from the edge attr value vector.
   TFltV GetFltVAttrDatE(const TEdgeI& EdgeI, const TStr& attr) { return GetFltVAttrDatE(EdgeI.GetId(), attr); }
   TFltV GetFltVAttrDatE(const int& EId, const TStr& attr);
 
@@ -2817,7 +2817,7 @@ public:
   /// Adds a new IntV node attribute to the hashmap.
   int AddIntVAttrN(const TStr& attr, TBool UseDense=true);
 
-  /// Avery: Adds a new FltV node attribute to the hashmap.
+  /// Adds a new FltV node attribute to the hashmap.
   int AddFltVAttrN(const TStr& attr, TBool UseDense=true);
 
   /// Adds a new Int edge attribute to the hashmap.
@@ -2829,7 +2829,7 @@ public:
   /// Adds a new IntV edge attribute to the hashmap.
   int AddIntVAttrE(const TStr& attr, TBool UseDense=true);
 
-  /// Avery: Adds a new IntV edge attribute to the hashmap.
+  /// Adds a new FltV edge attribute to the hashmap.
   int AddFltVAttrE(const TStr& attr, TBool UseDense=true);
 
   /// Removes all the values for node attr.
@@ -2843,7 +2843,7 @@ public:
   bool IsIntAttrDeletedN(const int& NId, const TStr& attr) const;
   /// Returns true if IntV \c attr exists for node \c NId and is an empty vector.
   bool IsIntVAttrDeletedN(const int& NId, const TStr& attr) const;
-  /// Avery: Returns true if FltV \c attr exists for node \c NId and is an empty vector.
+  /// Returns true if FltV \c attr exists for node \c NId and is an empty vector.
   bool IsFltVAttrDeletedN(const int& NId, const TStr& attr) const;
   /// Returns true if Str \c attr exists for node \c NId and has default value.
   bool IsStrAttrDeletedN(const int& NId, const TStr& attr) const;
@@ -2869,7 +2869,7 @@ public:
   bool IsIntAttrDeletedE(const int& EId, const TStr& attr) const;
   /// Returns true if IntV \c attr exists for edge \c EId and is an empty vector.
   bool IsIntVAttrDeletedE(const int& EId, const TStr& attr) const;
-  /// Avery: Returns true if FltV \c attr exists for edge \c EId and is an empty vector.
+  /// Returns true if FltV \c attr exists for edge \c EId and is an empty vector.
   bool IsFltVAttrDeletedE(const int& EId, const TStr& attr) const;
   /// Returns true if Str \c attr exists for edge \c NId and has default value.
   bool IsStrAttrDeletedE(const int& EId, const TStr& attr) const;
@@ -2882,7 +2882,7 @@ public:
   bool EdgeAttrIsIntDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
   /// Returns true if EId attr deleted for current edge int vector attr iterator.
   bool EdgeAttrIsIntVDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
-  /// Avery: Returns true if EId attr deleted for current edge flt vector attr iterator.
+  /// Returns true if EId attr deleted for current edge flt vector attr iterator.
   bool EdgeAttrIsFltVDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
   /// Returns true if EId attr deleted for current edge str attr iterator.
   bool EdgeAttrIsStrDeleted(const int& EId, const TStrIntPrH::TIter& EdgeHI) const;
@@ -3020,7 +3020,6 @@ public:
     return GetSAttrVN(NodeI.GetId(), AttrType, AttrV);
   }
 
-  // Avery: unsure about these
   /// Gets a list of all nodes that have a sparse attribute with name \c AttrName.
   int GetIdVSAttrN(const TStr& AttrName, TIntV& IdV) const;
   /// Gets a list of all nodes that have a sparse attribute with id \c AttrId.
@@ -3138,7 +3137,6 @@ public:
     return GetSAttrVE(EdgeI.GetId(), AttrType, AttrV);
   }
 
-  // Avery: unsure
   /// Gets a list of all edges that have a sparse attribute with name \c AttrName.
   int GetIdVSAttrE(const TStr& AttrName, TIntV& IdV) const;
   /// Gets a list of all edges that have a sparse attribute with id \c AttrId.

--- a/snap-core/network.h
+++ b/snap-core/network.h
@@ -1905,6 +1905,7 @@ protected:
   TVec<TVec<TIntV> > VecOfIntVecVecsN, VecOfIntVecVecsE;
   TVec<TVec<TFltV> > VecOfFltVecVecsN, VecOfFltVecVecsE; // added by Avery
   TVec<THash<TInt, TIntV> > VecOfIntHashVecsN, VecOfIntHashVecsE;
+  TVec<THash<TInt, TFltV> > VecOfFltHashVecsN, VecOfFltHashVecsE;
   enum { IntType, StrType, FltType, IntVType, FltVType };
 
   TAttr SAttrN;
@@ -1965,7 +1966,9 @@ public:
     VecOfIntVecsN(), VecOfIntVecsE(), VecOfStrVecsN(), VecOfStrVecsE(),
     VecOfFltVecsN(), VecOfFltVecsE(),  VecOfIntVecVecsN(), VecOfIntVecVecsE(),
     VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
-    VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE(){ }
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(), 
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(), // added by Avery
+    SAttrN(), SAttrE(){ }
   /// Constructor that reserves enough memory for a graph of nodes and edges.
   explicit TNEANet(const int& Nodes, const int& Edges) : CRef(),
     MxNId(0), MxEId(0), NodeH(), EdgeH(), KeyToIndexTypeN(), KeyToIndexTypeE(), KeyToDenseN(), KeyToDenseE(),
@@ -1973,7 +1976,9 @@ public:
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
     VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
     VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
-    VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE()
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(), 
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(), // added by Avery
+    SAttrN(), SAttrE()
     { Reserve(Nodes, Edges); }
   TNEANet(const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
     NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(), KeyToIndexTypeE(), KeyToDenseN(), KeyToDenseE(),
@@ -1981,7 +1986,9 @@ public:
     FltDefaultsN(), FltDefaultsE(), VecOfIntVecsN(), VecOfIntVecsE(),
     VecOfStrVecsN(), VecOfStrVecsE(), VecOfFltVecsN(), VecOfFltVecsE(), VecOfIntVecVecsN(), VecOfIntVecVecsE(),
     VecOfFltVecVecsN(), VecOfFltVecVecsE(), // added by Avery
-    VecOfIntHashVecsN(), VecOfIntHashVecsE(), SAttrN(), SAttrE() { }
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(), 
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(), // added by Avery
+    SAttrN(), SAttrE() { }
   /// Constructor for loading the graph from a (binary) stream SIn.
   TNEANet(TSIn& SIn) : MxNId(SIn), MxEId(SIn), NodeH(SIn), EdgeH(SIn),
     KeyToIndexTypeN(SIn), KeyToIndexTypeE(SIn), KeyToDenseN(SIn), KeyToDenseE(SIn), IntDefaultsN(SIn), IntDefaultsE(SIn),
@@ -1990,6 +1997,7 @@ public:
     VecOfFltVecsN(SIn), VecOfFltVecsE(SIn), VecOfIntVecVecsN(SIn), VecOfIntVecVecsE(SIn), 
     VecOfFltVecVecsN(SIn), VecOfFltVecVecsE(SIn), // added by Avery
     VecOfIntHashVecsN(SIn), VecOfIntHashVecsE(SIn),
+    VecOfFltHashVecsN(SIn), VecOfFltHashVecsE(SIn), // added by Avery
     SAttrN(SIn), SAttrE(SIn) { }
 protected:
   TNEANet(const TNEANet& Graph, bool modeSubGraph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
@@ -1999,7 +2007,9 @@ protected:
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
     VecOfIntVecVecsN(), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), 
     VecOfFltVecVecsN(), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), // added by Avery
-    VecOfIntHashVecsN(), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE) { }
+    VecOfIntHashVecsN(), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE),
+    VecOfFltHashVecsN(), VecOfFltHashVecsE(Graph.VecOfFltHashVecsE) // added by Avery
+     { }
   TNEANet(bool copyAll, const TNEANet& Graph) : MxNId(Graph.MxNId), MxEId(Graph.MxEId),
     NodeH(Graph.NodeH), EdgeH(Graph.EdgeH), KeyToIndexTypeN(Graph.KeyToIndexTypeN), KeyToIndexTypeE(Graph.KeyToIndexTypeE), KeyToDenseN(Graph.KeyToDenseN), KeyToDenseE(Graph.KeyToDenseE),
     IntDefaultsN(Graph.IntDefaultsN), IntDefaultsE(Graph.IntDefaultsE), StrDefaultsN(Graph.StrDefaultsN), StrDefaultsE(Graph.StrDefaultsE),
@@ -2007,7 +2017,9 @@ protected:
     VecOfStrVecsN(Graph.VecOfStrVecsN), VecOfStrVecsE(Graph.VecOfStrVecsE), VecOfFltVecsN(Graph.VecOfFltVecsN), VecOfFltVecsE(Graph.VecOfFltVecsE),
     VecOfIntVecVecsN(Graph.VecOfIntVecVecsN), VecOfIntVecVecsE(Graph.VecOfIntVecVecsE), 
     VecOfFltVecVecsN(Graph.VecOfFltVecVecsN), VecOfFltVecVecsE(Graph.VecOfFltVecVecsE), // added by Avery
-    VecOfIntHashVecsN(Graph.VecOfIntHashVecsN), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE), SAttrN(Graph.SAttrN), SAttrE(Graph.SAttrE) { }
+    VecOfIntHashVecsN(Graph.VecOfIntHashVecsN), VecOfIntHashVecsE(Graph.VecOfIntHashVecsE), 
+    VecOfFltHashVecsN(Graph.VecOfFltHashVecsN), VecOfFltHashVecsE(Graph.VecOfFltHashVecsE), // added by Avery
+    SAttrN(Graph.SAttrN), SAttrE(Graph.SAttrE) { }
   // virtual ~TNEANet() { }cd ..
 public:
   /// Saves the graph to a (binary) stream SOut. Expects data structures for sparse attributes.
@@ -2024,6 +2036,7 @@ public:
     VecOfIntVecVecsN.Save(SOut); VecOfIntVecVecsE.Save(SOut);
     VecOfFltVecVecsN.Save(SOut); VecOfFltVecVecsE.Save(SOut); // added by Avery
     VecOfIntHashVecsN.Save(SOut); VecOfIntHashVecsE.Save(SOut); 
+    VecOfFltHashVecsN.Save(SOut); VecOfFltHashVecsE.Save(SOut); // added by Avery
     SAttrN.Save(SOut); SAttrE.Save(SOut); }
   /// Saves the graph to a (binary) stream SOut. Available for backwards compatibility.
   void Save_V1(TSOut& SOut) const {
@@ -2133,6 +2146,42 @@ public:
       }
     }
     VecOfIntVecVecsE.Clr();
+  
+    VecLength = VecOfFltVecVecsN.Len();
+    if (VecLength != 0) {
+      VecOfFltHashVecsN = TVec<THash<TInt, TFltV> >(VecLength);
+      for (iter = KeyToIndexTypeN.BegI(); !iter.IsEnd(); iter=iter.Next()) {
+        if (iter.GetDat().Val1 == FltVType) {
+          TStr attribute = iter.GetKey();
+          TInt index = iter.GetDat().Val2();
+          for (int i=0; i<VecOfFltVecVecsN[index].Len(); i++) {
+            if(VecOfFltVecVecsN[index][i].Len() > 0) {
+              VecOfFltHashVecsN[index].AddDat(TInt(i), VecOfFltVecVecsN[index][i]);
+            }
+          }
+          KeyToDenseN.AddDat(attribute, TBool(false));
+        }
+      }
+    }
+    VecOfFltVecVecsN.Clr();
+
+    VecLength = VecOfFltVecVecsE.Len();
+    if (VecLength != 0) {
+      VecOfFltHashVecsE = TVec<THash<TInt, TFltV> >(VecLength);
+      for (iter = KeyToIndexTypeE.BegI(); !iter.IsEnd(); iter=iter.Next()) {
+        if (iter.GetDat().Val1 == FltVType) {
+          TStr attribute = iter.GetKey();
+          TInt index = iter.GetDat().Val2();
+          for (int i=0; i<VecOfFltVecVecsE[index].Len(); i++) {
+            if(VecOfFltVecVecsE[index][i].Len() > 0) {
+              VecOfFltHashVecsE[index].AddDat(TInt(i), VecOfFltVecVecsE[index][i]);
+            }
+          }
+          KeyToDenseE.AddDat(attribute, TBool(false));
+        }
+      }
+    }
+    VecOfFltVecVecsE.Clr();
   }
 
 

--- a/test/test-TNEANet.cpp
+++ b/test/test-TNEANet.cpp
@@ -424,6 +424,126 @@ TEST(TNEANet, FltVAttr2) {
   }
 }
 
+TEST(TNEANet, IntVDelAttr) {
+  PNEANet Graph = TNEANet::New();
+  TIntV test;
+  int numNodes = 10;
+  Graph->AddIntVAttrN("nodeAttrEmpty");
+  Graph->AddIntVAttrN("nodeAttrOne");
+  Graph->AddIntVAttrN("edgeAttrEmpty");
+  Graph->AddIntVAttrN("edgeAttrOne");
+  
+  for (int i = 0; i < 10; ++i) {
+    Graph->AddNode(i);
+
+    TIntV single;
+    single.Add(i);
+    single.Add(i+1);
+    Graph->AddIntVAttrDatN(i, single, "nodeAttrOne");
+
+    if (i > 0) {
+      TInt edgeID = Graph->AddEdge(i-1, i);
+      single.Add(i-1);
+      Graph->AddIntVAttrDatE(edgeID, single, "edgeAttrOne");
+    }
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(Graph->DelFromIntVAttrDatN(i, i, "nodeAttrOne"), 0);
+    EXPECT_EQ(Graph->DelFromIntVAttrDatN(i, i, "nodeAttrEmpty"), -1);
+    EXPECT_EQ(Graph->DelFromIntVAttrDatN(i, i, "nodeAttrOne"), -1);
+
+    TIntV vec = Graph->GetIntVAttrDatN(i, "nodeAttrOne");
+    EXPECT_EQ(vec.Len(), 1);
+    EXPECT_EQ(vec[0], i+1);
+  }
+
+  // what about for the edges?
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(Graph->IsAttrDeletedN(i, "nodeAttrOne"), false);
+    EXPECT_EQ(Graph->IsIntVAttrDeletedN(i, "nodeAttrOne"), false);
+    Graph->DelAttrDatN(i, "nodeAttrOne");
+    EXPECT_EQ(Graph->IsAttrDeletedN(i, "nodeAttrOne"), true);
+    EXPECT_EQ(Graph->IsIntVAttrDeletedN(i, "nodeAttrOne"), true);
+
+    TIntV vec = Graph->GetIntVAttrDatN(i, "nodeAttrOne");
+    EXPECT_EQ(vec.Len(), 0);
+  }
+
+  for (int i = 1; i < 10; ++i) {
+    TInt edgeID = Graph->GetEId(i-1, i);
+    EXPECT_EQ(Graph->IsAttrDeletedE(edgeID, "edgeAttrOne"), false);
+    EXPECT_EQ(Graph->IsIntVAttrDeletedE(edgeID, "edgeAttrOne"), false);
+    Graph->DelAttrDatE(edgeID, "edgeAttrOne");
+    EXPECT_EQ(Graph->IsAttrDeletedE(edgeID, "edgeAttrOne"), true);
+    EXPECT_EQ(Graph->IsIntVAttrDeletedE(edgeID, "edgeAttrOne"), true);
+
+    TIntV vec = Graph->GetIntVAttrDatE(edgeID, "edgeAttrOne");
+    EXPECT_EQ(vec.Len(), 0);
+  }
+}
+
+TEST(TNEANet, FltVDelAttr) {
+  PNEANet Graph = TNEANet::New();
+  TFltV test;
+  int numNodes = 10;
+  Graph->AddFltVAttrN("nodeAttrEmpty");
+  Graph->AddFltVAttrN("nodeAttrOne");
+  Graph->AddFltVAttrN("edgeAttrEmpty");
+  Graph->AddFltVAttrN("edgeAttrOne");
+  
+  for (int i = 0; i < 10; ++i) {
+    Graph->AddNode(i);
+
+    TFltV single;
+    single.Add(i-1.5);
+    single.Add(i+1.5);
+    Graph->AddFltVAttrDatN(i, single, "nodeAttrOne");
+
+    if (i > 0) {
+      TInt edgeID = Graph->AddEdge(i-1, i);
+      single.Add(i-1);
+      Graph->AddFltVAttrDatE(edgeID, single, "edgeAttrOne");
+    }
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(Graph->DelFromFltVAttrDatN(i, i-1.5, "nodeAttrOne"), 0);
+    EXPECT_EQ(Graph->DelFromFltVAttrDatN(i, i-1.5, "nodeAttrEmpty"), -1);
+    EXPECT_EQ(Graph->DelFromFltVAttrDatN(i, i-1.5, "nodeAttrOne"), -1);
+
+    TFltV vec = Graph->GetFltVAttrDatN(i, "nodeAttrOne");
+    EXPECT_EQ(vec.Len(), 1);
+    EXPECT_FLOAT_EQ(vec[0], i+1.5);
+  }
+
+  // what about for the edges?
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(Graph->IsAttrDeletedN(i, "nodeAttrOne"), false);
+    EXPECT_EQ(Graph->IsFltVAttrDeletedN(i, "nodeAttrOne"), false);
+    Graph->DelAttrDatN(i, "nodeAttrOne");
+    EXPECT_EQ(Graph->IsAttrDeletedN(i, "nodeAttrOne"), true);
+    EXPECT_EQ(Graph->IsFltVAttrDeletedN(i, "nodeAttrOne"), true);
+
+    TFltV vec = Graph->GetFltVAttrDatN(i, "nodeAttrOne");
+    EXPECT_EQ(vec.Len(), 0);
+  }
+
+  for (int i = 1; i < 10; ++i) {
+    TInt edgeID = Graph->GetEId(i-1, i);
+    EXPECT_EQ(Graph->IsAttrDeletedE(edgeID, "edgeAttrOne"), false);
+    EXPECT_EQ(Graph->IsFltVAttrDeletedE(edgeID, "edgeAttrOne"), false);
+    Graph->DelAttrDatE(edgeID, "edgeAttrOne");
+    EXPECT_EQ(Graph->IsAttrDeletedE(edgeID, "edgeAttrOne"), true);
+    EXPECT_EQ(Graph->IsFltVAttrDeletedE(edgeID, "edgeAttrOne"), true);
+
+    TFltV vec = Graph->GetFltVAttrDatE(edgeID, "edgeAttrOne");
+    EXPECT_EQ(vec.Len(), 0);
+  }
+}
+
 // Test node, edge attribute functionality
 TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   int NNodes = 1000;

--- a/test/test-TNEANet.cpp
+++ b/test/test-TNEANet.cpp
@@ -206,6 +206,224 @@ TEST(TNEANet, IntVAttr) {
 
 }
 
+// Tests AddIntVAttrDatN/E, GetIntVAttrDatN/E, AppendIntVAttrDatN/E
+TEST(TNEANet, IntVAttr2) {
+  PNEANet Graph = TNEANet::New();
+  TIntV test;
+  int numNodes = 10;
+  Graph->AddIntVAttrN("size");
+  Graph->AddIntVAttrN("single");
+  
+  for (int i = 0; i < 10; ++i) {
+    Graph->AddNode(i);
+    TIntV size(i);
+    Graph->AddIntVAttrDatN(i, size, "size");
+
+    TIntV single;
+    single.Add(i);
+    Graph->AddIntVAttrDatN(i, single, "single");
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    TIntV size_check = Graph->GetIntVAttrDatN(i, "size");
+    TIntV single_check = Graph->GetIntVAttrDatN(i, "single");
+
+    TIntV size(i);
+    TIntV single;
+    single.Add(i);
+
+    EXPECT_EQ(size, size_check);
+    EXPECT_EQ(single, single_check);
+
+    Graph->AppendIntVAttrDatN(i, -i, "single");
+    single.Add(-i);
+
+    single_check = Graph->GetIntVAttrDatN(i, "single");
+    EXPECT_EQ(single, single_check);
+  }
+
+  Graph->AddIntVAttrE("cost");
+  Graph->AddIntVAttrE("reward");
+
+
+  for (int i = 0; i < 10; i++) {
+    for (int j = i+1; j < 10; j++) {
+      EXPECT_EQ(Graph->IsEdge(i, j), false);
+      TInt edgeID = Graph->AddEdge(i, j);
+      EXPECT_EQ(Graph->IsEdge(edgeID), true);
+      
+      TIntV costs;
+      costs.Add(i+j);
+
+      Graph->AddIntVAttrDatE(edgeID, costs, "cost");
+      Graph->AppendIntVAttrDatE(edgeID, i+j, "cost");
+      costs.Add(i+j);
+      Graph->AddIntVAttrDatE(edgeID, costs, "reward");
+      
+      TIntV cost_val = Graph->GetIntVAttrDatE(edgeID, "cost");
+      TIntV reward_val = Graph->GetIntVAttrDatE(edgeID, "reward");
+      
+      EXPECT_EQ(cost_val.Len(), 2);
+      EXPECT_EQ(reward_val.Len(), 2);
+
+      for (int d = 0; d < 2; d++) {
+        EXPECT_EQ(cost_val[d], i+j);
+        EXPECT_EQ(reward_val[d], i+j);
+      }
+    }
+  }
+
+  for (int i = 0; i < 10; i++) {
+    for (int j = i+1; j < 10; j++) {
+      TInt edgeID = Graph->GetEId(i, j);
+      EXPECT_EQ(Graph->IsEdge(edgeID), true);
+
+      TIntV cost_val = Graph->GetIntVAttrDatE(edgeID, "cost");
+      TIntV reward_val = Graph->GetIntVAttrDatE(edgeID, "reward");
+
+      EXPECT_EQ(cost_val.Len(), 2);
+      EXPECT_EQ(reward_val.Len(), 2);
+
+      for (int d = 0; d < 2; d++) {
+        EXPECT_EQ(cost_val[d], i+j);
+        EXPECT_EQ(reward_val[d], i+j);
+      }
+    }
+  }
+}
+
+// Avery
+TEST(TNEANet, FltVAttr) {
+  PNEANet Graph;
+  Graph = TNEANet::New();
+  int i;
+  TFltV test;
+  int numNodes = 10;
+  Graph->AddNode(0);
+  for (i = 1; i < numNodes; i++) {
+    Graph->AddNode(i);
+    Graph->AddEdge(i-1, i);
+  }
+  TStr TestAttr("Test1");
+  Graph->AddFltVAttrN(TestAttr);
+  for (i = 0; i < numNodes; i++) {
+    test = Graph->GetFltVAttrDatN(i, TestAttr);
+    EXPECT_EQ(0, test.Len());
+  }
+
+  TFltV testVB;
+  for (i = 0; i < numNodes; i++) {
+    testVB.Add(i);
+  }
+  const TFltV testV = testVB;
+  Graph->AddFltVAttrDatN(0, testV, TestAttr);
+  test = Graph->GetFltVAttrDatN(0, TestAttr);
+  EXPECT_EQ(numNodes, test.Len());
+
+  for (i = 0; i < numNodes; i++) {
+    EXPECT_EQ(test[i], i + 0.0);
+  }
+
+  Graph->AppendFltVAttrDatN(0, numNodes, TestAttr);
+  test = Graph->GetFltVAttrDatN(0, TestAttr);
+  EXPECT_EQ(numNodes+1, test.Len());
+  for (i = 0; i < numNodes+1; i++) {
+    EXPECT_EQ(test[i], i + 0.0);
+  }
+
+  Graph->DelAttrDatN(0, TestAttr);
+  for (i = 0; i < numNodes; i++) {
+    test = Graph->GetFltVAttrDatN(i, TestAttr);
+    EXPECT_EQ(0, test.Len());
+  }
+}
+
+// Tests AddIntVAttrDatN/E, GetIntVAttrDatN/E, AppendIntVAttrDatN/E
+TEST(TNEANet, FltVAttr2) {
+  PNEANet Graph = TNEANet::New();
+  TFltV test;
+  int numNodes = 10;
+  Graph->AddFltVAttrN("size");
+  Graph->AddFltVAttrN("single");
+  
+  for (int i = 0; i < 10; ++i) {
+    Graph->AddNode(i);
+    TFltV size(i);
+    Graph->AddFltVAttrDatN(i, size, "size");
+
+    TFltV single;
+    single.Add(i + 0.5);
+    Graph->AddFltVAttrDatN(i, single, "single");
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    TFltV size_check = Graph->GetFltVAttrDatN(i, "size");
+    TFltV single_check = Graph->GetFltVAttrDatN(i, "single");
+
+    TFltV size(i);
+    TFltV single;
+    single.Add(i + 0.5);
+
+    EXPECT_EQ(size, size_check);
+    EXPECT_EQ(single, single_check);
+
+    Graph->AppendFltVAttrDatN(i, -i + 0.5, "single");
+    single.Add(-i + 0.5);
+
+    single_check = Graph->GetFltVAttrDatN(i, "single");
+    EXPECT_EQ(single, single_check);
+  }
+
+  Graph->AddFltVAttrE("cost");
+  Graph->AddFltVAttrE("reward");
+
+  for (int i = 0; i < 10; i++) {
+    for (int j = i+1; j < 10; j++) {
+      EXPECT_EQ(Graph->IsEdge(i, j), false);
+      TInt edgeID = Graph->AddEdge(i, j);
+      EXPECT_EQ(Graph->IsEdge(edgeID), true);
+      
+      TFltV costs;
+      costs.Add(i+j+0.5);
+
+      Graph->AddFltVAttrDatE(edgeID, costs, "cost");
+      Graph->AppendFltVAttrDatE(edgeID, i+j+0.5, "cost");
+      costs.Add(i+j+0.5);
+      Graph->AddFltVAttrDatE(edgeID, costs, "reward");
+
+      
+      TFltV cost_val = Graph->GetFltVAttrDatE(edgeID, "cost");
+      TFltV reward_val = Graph->GetFltVAttrDatE(edgeID, "reward");
+      
+      EXPECT_EQ(cost_val.Len(), 2);
+      EXPECT_EQ(reward_val.Len(), 2);
+
+      for (int d = 0; d < 2; d++) {
+        EXPECT_FLOAT_EQ(cost_val[d], i+j+0.5);
+        EXPECT_FLOAT_EQ(reward_val[d], i+j+0.5);
+      }
+    }
+  }
+
+  for (int i = 0; i < 10; i++) {
+    for (int j = i+1; j < 10; j++) {
+      TInt edgeID = Graph->GetEId(i, j);
+      EXPECT_EQ(Graph->IsEdge(edgeID), true);
+
+      TFltV cost_val = Graph->GetFltVAttrDatE(edgeID, "cost");
+      TFltV reward_val = Graph->GetFltVAttrDatE(edgeID, "reward");
+
+      EXPECT_EQ(cost_val.Len(), 2);
+      EXPECT_EQ(reward_val.Len(), 2);
+
+      for (int d = 0; d < 2; d++) {
+        EXPECT_FLOAT_EQ(cost_val[d], i+j+0.5);
+        EXPECT_FLOAT_EQ(reward_val[d], i+j+0.5);
+      }
+    }
+  }
+}
+
 // Test node, edge attribute functionality
 TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   int NNodes = 1000;

--- a/test/test-TNEANet.cpp
+++ b/test/test-TNEANet.cpp
@@ -544,6 +544,151 @@ TEST(TNEANet, FltVDelAttr) {
   }
 }
 
+TEST(TNEANet, IntVIterator) {
+  PNEANet Graph = TNEANet::New();
+  int numNodes = 10;
+  TStr TestAttrNodes("path");
+  TStr TestAttrEdges("line");
+  TStr TestAttrNodesSparse("path_sparse");
+  TStr TestAttrEdgesSparse("line_sparse");
+  Graph->AddIntVAttrN(TestAttrNodes);
+  Graph->AddIntVAttrE(TestAttrEdges);
+  Graph->AddIntVAttrN(TestAttrNodesSparse, false);
+  Graph->AddIntVAttrE(TestAttrEdgesSparse, false);
+
+  Graph->AddNode(0);
+  for (int i = 1; i < numNodes; i++) {
+    Graph->AddNode(i);
+    Graph->AddEdge(i-1, i);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    TIntV testVB;
+    testVB.Add(i);
+    Graph->AddIntVAttrDatN(i, testVB, TestAttrNodes);
+    Graph->AddIntVAttrDatN(i, testVB, TestAttrNodesSparse, false);
+
+    if (i > 0) {
+      TInt edgeID = Graph->GetEId(i-1, i);
+      Graph->AddIntVAttrDatE(edgeID, testVB, TestAttrEdges);
+      Graph->AddIntVAttrDatE(edgeID, testVB, TestAttrEdgesSparse, false);
+    }
+  }
+
+  int count = 0;
+  TVec<TVec<TInt> > nodeAttrs = TVec<TVec<TInt> >();
+  TVec<TVec<TInt> > edgeAttrs = TVec<TVec<TInt> >();
+  TVec<TVec<TInt> > nodeAttrsSparse = TVec<TVec<TInt> >();
+  TVec<TVec<TInt> > edgeAttrsSparse = TVec<TVec<TInt> >();
+
+  for (TNEANet::TAIntVI NI = Graph->BegNAIntVI(TestAttrNodes); NI < Graph->EndNAIntVI(TestAttrNodes); NI++) {
+    nodeAttrs.Add(NI.GetDat());
+  }
+
+  for (TNEANet::TAIntVI EI = Graph->BegEAIntVI(TestAttrEdges); EI < Graph->EndEAIntVI(TestAttrEdges); EI++) {
+    edgeAttrs.Add(EI.GetDat());
+  }
+
+  for (TNEANet::TAIntVI NI = Graph->BegNAIntVI(TestAttrNodesSparse); NI < Graph->EndNAIntVI(TestAttrNodesSparse); NI++) {
+    nodeAttrsSparse.Add(NI.GetDat());
+  }
+
+  for (TNEANet::TAIntVI EI = Graph->BegEAIntVI(TestAttrEdgesSparse); EI < Graph->EndEAIntVI(TestAttrEdgesSparse); EI++) {
+    edgeAttrsSparse.Add(EI.GetDat());
+  }
+
+  EXPECT_EQ(nodeAttrs.Len(), numNodes);
+  EXPECT_EQ(edgeAttrs.Len(), numNodes-1);
+  EXPECT_EQ(nodeAttrsSparse.Len(), numNodes);
+  EXPECT_EQ(edgeAttrsSparse.Len(), numNodes-1);
+
+  for (int i = 0; i < numNodes; i++) {
+    TIntV testVB;
+    testVB.Add(i);
+    EXPECT_EQ(nodeAttrs.IsIn(testVB), true);
+    EXPECT_EQ(nodeAttrsSparse.IsIn(testVB), true);
+
+    if (i > 0) {
+      EXPECT_EQ(edgeAttrs.IsIn(testVB), true);
+      EXPECT_EQ(edgeAttrsSparse.IsIn(testVB), true);
+    }
+  }
+  
+}
+
+TEST(TNEANet, FltVIterator) {
+  PNEANet Graph = TNEANet::New();
+  int numNodes = 10;
+  TStr TestAttrNodes("path");
+  TStr TestAttrEdges("line");
+  TStr TestAttrNodesSparse("path_sparse");
+  TStr TestAttrEdgesSparse("line_sparse");
+  Graph->AddFltVAttrN(TestAttrNodes);
+  Graph->AddFltVAttrE(TestAttrEdges);
+  Graph->AddFltVAttrN(TestAttrNodesSparse, false);
+  Graph->AddFltVAttrE(TestAttrEdgesSparse, false);
+
+  Graph->AddNode(0);
+  for (int i = 1; i < numNodes; i++) {
+    Graph->AddNode(i);
+    Graph->AddEdge(i-1, i);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    TFltV testVB;
+    testVB.Add(i+0.5);
+    Graph->AddFltVAttrDatN(i, testVB, TestAttrNodes);
+    Graph->AddFltVAttrDatN(i, testVB, TestAttrNodesSparse, false);
+
+    if (i > 0) {
+      TInt edgeID = Graph->GetEId(i-1, i);
+      Graph->AddFltVAttrDatE(edgeID, testVB, TestAttrEdges);
+      Graph->AddFltVAttrDatE(edgeID, testVB, TestAttrEdgesSparse, false);
+    }
+  }
+
+  int count = 0;
+  TVec<TVec<TFlt> > nodeAttrs = TVec<TVec<TFlt> >();
+  TVec<TVec<TFlt> > edgeAttrs = TVec<TVec<TFlt> >();
+  TVec<TVec<TFlt> > nodeAttrsSparse = TVec<TVec<TFlt> >();
+  TVec<TVec<TFlt> > edgeAttrsSparse = TVec<TVec<TFlt> >();
+
+  for (TNEANet::TAFltVI NI = Graph->BegNAFltVI(TestAttrNodes); NI < Graph->EndNAFltVI(TestAttrNodes); NI++) {
+    nodeAttrs.Add(NI.GetDat());
+  }
+
+  for (TNEANet::TAFltVI EI = Graph->BegEAFltVI(TestAttrEdges); EI < Graph->EndEAFltVI(TestAttrEdges); EI++) {
+    edgeAttrs.Add(EI.GetDat());
+  }
+
+  for (TNEANet::TAFltVI NI = Graph->BegNAFltVI(TestAttrNodesSparse); NI < Graph->EndNAFltVI(TestAttrNodesSparse); NI++) {
+    nodeAttrsSparse.Add(NI.GetDat());
+  }
+
+  for (TNEANet::TAFltVI EI = Graph->BegEAFltVI(TestAttrEdgesSparse); EI < Graph->EndEAFltVI(TestAttrEdgesSparse); EI++) {
+    edgeAttrsSparse.Add(EI.GetDat());
+  }
+
+  EXPECT_EQ(nodeAttrs.Len(), numNodes);
+  EXPECT_EQ(edgeAttrs.Len(), numNodes-1);
+  EXPECT_EQ(nodeAttrsSparse.Len(), numNodes);
+  EXPECT_EQ(edgeAttrsSparse.Len(), numNodes-1);
+
+  for (int i = 0; i < numNodes; i++) {
+    TFltV testVB;
+    testVB.Add(i + 0.5);
+    EXPECT_EQ(nodeAttrs.IsIn(testVB), true);
+    EXPECT_EQ(nodeAttrsSparse.IsIn(testVB), true);
+
+    if (i > 0) {
+      EXPECT_EQ(edgeAttrs.IsIn(testVB), true);
+      EXPECT_EQ(edgeAttrsSparse.IsIn(testVB), true);
+    }
+  }
+  
+}
+
+
 // Test node, edge attribute functionality
 TEST(TNEANet, ManipulateNodesEdgeAttributes) {
   int NNodes = 1000;

--- a/test/test-TNEANet.cpp
+++ b/test/test-TNEANet.cpp
@@ -922,7 +922,9 @@ TEST(TNEANet, AddSAttrN) {
   PNEANet Graph;
   Graph = TNEANet::New();
   TInt AttrId;
+  //std::cout << "NO crash?" << std::endl;
   int status = Graph->AddSAttrN("TestInt", atInt, AttrId);
+  //std::cout << "NO crash?" << std::endl;
   EXPECT_EQ(0, status);
   EXPECT_EQ(0, AttrId.Val);
   status = Graph->AddSAttrN("TestFlt", atFlt, AttrId);


### PR DESCRIPTION
Pull request contains:
- dense floating-point vector attribute support with public methods analogous to the existing int vector attribute methods.
- iterators for floating-point vector attributes (an iterator for each element for a particular attribute)
- improved tests for int vector attribute methods, new tests for floating vector attribute methods
- added tests for int and float vector attribute delete functions
- fixed bugs in original int vector attribute edge methods - incorrect use of edge ID vs. node ID.
- implementation of sparse floating-point vectors and their iterators.
- tests: iterators for int vector attributes (originally lacking) and floating-point vector attributes, both sparse and dense representations.