### PR TITLE
Bugfix: Motifcluster ARPACK error

### DIFF
--- a/snap-adv/motifcluster.cpp
+++ b/snap-adv/motifcluster.cpp
@@ -1004,7 +1004,7 @@ void SymeigsSmallest(const TSparseColMatrix& A, int nev, TFltV& evals,
       result[i] = load[i];
     }
 
-    if (ido == 1) {
+    if (ido == -1 || ido == 1) {
       // Need another matrix-vector product.
       A.Multiply(result, Ax);
       double *store = &workd[ipntr[1] - 1];


### PR DESCRIPTION
Due to a suspected change in the functionality of the `dsaupd` ARPACK routine, running `./motifclustermain` in `examples/motifcluster` produces an error:

```
Motifs. build: 14:30:25, Mar  3 2026. Time: 14:31:28 [Nov 13 2025]
==================================================================
usage: motifclustermain
   -i:Input directed graph file (default:'../as20graph.txt')
   -m:Motif type (default:'M4')
*** Error: ARPACK error

run time: 0.12s (14:31:28)
```

This was previously flagged by issues #251 and #235 .

Looking at the `dsaupd` [doc](https://github.com/opencollab/arpack-ng/blob/f73592dd1e5e39c469ade3587db76794ddfa171d/SRC/dsaupd.f#L79), `Y = OP * X` should be calculated when `IDO == 1` or when `IDO == -1`.

In `motifcluster.cpp`, this is currently done in the case of `IDO == 1`. I added the missing condition for `IDO == -1`, resolving the issue. The ARPACK error does not appear anymore, and the expected result is calculated:

```
Motifs. build: 14:31:33, Mar  3 2026. Time: 14:31:40 [Nov 13 2025]
==================================================================
usage: motifclustermain
   -i:Input directed graph file (default:'../as20graph.txt')
   -m:Motif type (default:'M4')
Largest CC size: 2336
Cluster size: 10
Motif conductance in largest CC: 0.045455
Eigenvalue: 0.037186

run time: 0.24s (14:31:41)
```